### PR TITLE
docs(branding): Update documentation to DoIt branding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-01-10
 - N/A (no database) (013-publish-pypi)
 - Bash scripts, gh CLI, Markdown (YAML for templates) + gh CLI (GitHub CLI), Gi (014-github-repo-protections)
 - N/A (GitHub API / repository settings) (014-github-repo-protections)
+- Markdown, JSON (documentation files) + None (text editing only) (015-docs-branding-cleanup)
+- N/A (file system) (015-docs-branding-cleanup)
 
 - Markdown (command definitions), Bash 5.x (scripts), Python 3.11+ (CLI) + Claude Code slash command system, GitHub MCP server, typer, rich, httpx (001-doit-command-refactor)
 
@@ -36,9 +38,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Markdown (command definitions), Bash 5.x (scripts), Python 3.11+ (CLI): Follow standard conventions
 
 ## Recent Changes
+- 015-docs-branding-cleanup: Added Markdown, JSON (documentation files) + None (text editing only)
 - 014-github-repo-protections: Added Bash scripts, gh CLI, Markdown (YAML for templates) + gh CLI (GitHub CLI), Gi
 - 013-publish-pypi: Added Python 3.11+ + hatchling (build), typer (CLI), rich (formatting)
-- 012-command-recommendations: Added Markdown (command templates), Bash 5.x (scripts) + Claude Code slash command system, existing doit template structure
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -56,13 +56,13 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "Spec Kit Documentation",
-      "_appName": "Spec Kit",
-      "_appFooter": "Spec Kit - A specification-driven development toolkit",
+      "_appTitle": "DoIt Documentation",
+      "_appName": "DoIt",
+      "_appFooter": "DoIt - A specification-driven development toolkit",
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/github/spec-kit",
+        "repo": "https://github.com/seanbarlow/doit",
         "branch": "main"
       }
     }

--- a/docs/features/015-docs-branding-cleanup.md
+++ b/docs/features/015-docs-branding-cleanup.md
@@ -1,0 +1,99 @@
+# Documentation Branding Cleanup
+
+**Completed**: 2026-01-12
+**Branch**: 015-docs-branding-cleanup
+**PR**: Pending
+
+## Overview
+
+Clean up all documentation files to remove legacy "Spec Kit" and "specify" branding references, replacing them with correct "DoIt" and "doit" branding. Updated all AI agent references to reflect the officially supported agents: Claude and GitHub Copilot only (removing references to Gemini, Codebuddy, and other unsupported agents).
+
+## Requirements Implemented
+
+| ID | Description | Status |
+|----|-------------|--------|
+| FR-001 | Replace "Spec Kit" with "DoIt" (proper noun) | Done |
+| FR-002 | Replace "spec-kit" with "doit" in package/repo names | Done |
+| FR-003 | Replace "specify" CLI command with "doit" | Done |
+| FR-004 | Replace "specify-cli" with "doit-toolkit-cli" in package names | Done |
+| FR-005 | Update docfx.json metadata to reference "DoIt" | Done |
+| FR-006 | Replace "github.com/github/spec-kit" with "github.com/seanbarlow/doit" | Done |
+| FR-007 | Replace "github.github.io/spec-kit" with "seanbarlow.github.io/doit" | Done |
+| FR-008 | Update docfx.json `_gitContribute.repo` URL | Done |
+| FR-009 | Remove references to Gemini as supported agent | Done |
+| FR-010 | Remove references to Codebuddy as supported agent | Done |
+| FR-011 | installation.md lists only Claude and GitHub Copilot | Done |
+| FR-012 | upgrade.md shows only --ai claude and --ai copilot | Done |
+| FR-013 | Update docs/upgrade.md | Done |
+| FR-014 | Update docs/docfx.json | Done |
+| FR-015 | Update any other docs with legacy references | Done |
+
+## Technical Details
+
+- **Language/Version**: Markdown documentation updates only
+- **Dependencies**: None
+- **Testing**: Manual verification via grep commands
+
+### Key Decisions
+
+1. Historical feature documentation in `docs/features/` was preserved as it documents past migrations
+2. Script files in `.doit/scripts/` and other locations outside `docs/` were out of scope
+3. The English verb "specify" was preserved where it appears naturally in prose
+4. Updated installation.md to list all 11 doit commands (discovered during review)
+
+## Files Changed
+
+### Modified
+
+- `docs/upgrade.md` - 40 occurrences fixed (spec-kit, specify, gemini, GitHub URLs)
+- `docs/docfx.json` - 4 occurrences fixed (appTitle, appName, appFooter, gitContribute URL)
+- `docs/installation.md` - 6 occurrences fixed + all 11 commands listed
+- `docs/local-development.md` - 1 occurrence fixed (--ai gemini to --ai claude)
+
+### Preserved (Historical)
+
+- `docs/features/006-docs-doit-migration.md` - Historical migration documentation
+- `docs/features/003-scaffold-doit-commands.md` - Historical migration documentation
+- `docs/features/update-doit-templates.md` - Historical migration documentation
+- `docs/features/004-review-template-commands.md` - Historical migration documentation
+- `docs/features/005-mermaid-visualization.md` - Historical command refs
+
+## Testing
+
+### Automated Tests
+
+N/A - Documentation-only feature
+
+### Manual Tests
+
+| Test | Result |
+|------|--------|
+| MT-001: Commands in upgrade.md use correct CLI names | PASS |
+| MT-002: Zero results for "spec-kit" or "Spec Kit" | PASS |
+| MT-003: docfx.json references "DoIt" and correct GitHub URLs | PASS |
+| MT-004: Zero results for "github/spec-kit" | PASS |
+| MT-005: installation.md shows only Claude and GitHub Copilot | PASS |
+| MT-006: Zero results for "gemini" | PASS |
+| MT-007: Zero results for "codebuddy" | PASS |
+| MT-008: upgrade.md --ai examples show only claude and copilot | PASS |
+| MT-009: GitHub links go to seanbarlow/doit | PASS |
+| MT-010: Release notes links point to seanbarlow/doit/releases | PASS |
+| MT-011: docfx.json gitContribute.repo URL is correct | PASS |
+
+## Success Criteria
+
+| ID | Criterion | Status |
+|----|-----------|--------|
+| SC-001 | Zero "spec-kit" matches in docs/ (excluding historical) | PASS |
+| SC-002 | Zero "Spec Kit" matches in docs/ (excluding historical) | PASS |
+| SC-003 | Zero "specify" CLI matches in docs/ (excluding historical) | PASS |
+| SC-004 | Zero "github/spec-kit" matches in docs/ | PASS |
+| SC-005 | Zero "gemini" matches in docs/ | PASS |
+| SC-006 | Zero "codebuddy" matches in docs/ | PASS |
+| SC-007 | All GitHub URLs point to seanbarlow/doit | PASS |
+| SC-008 | docfx.json contains correct branding and URL | PASS |
+
+## Related Issues
+
+- Epic: #31 - Documentation Branding Cleanup
+- Features: #32, #33, #34

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Linux/macOS** (or Windows; PowerShell scripts now supported without WSL)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Codebuddy CLI](https://www.codebuddy.ai/cli) or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code) or [GitHub Copilot](https://code.visualstudio.com/)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
@@ -32,9 +32,7 @@ You can proactively specify your AI agent during initialization:
 
 ```bash
 uvx doit-toolkit-cli init <project_name> --ai claude
-uvx doit-toolkit-cli init <project_name> --ai gemini
 uvx doit-toolkit-cli init <project_name> --ai copilot
-uvx doit-toolkit-cli init <project_name> --ai codebuddy
 ```
 
 ### Specify Script Type (Shell vs PowerShell)
@@ -66,9 +64,17 @@ uvx doit-toolkit-cli init <project_name> --ai claude --ignore-agent-tools
 
 After initialization, you should see the following commands available in your AI agent:
 
-- `/doit.doit` - Create specifications
-- `/doit.planit` - Generate implementation plans  
-- `/doit.taskit` - Break down into actionable tasks
+- `/doit.constitution` - Create or update project constitution
+- `/doit.scaffoldit` - Generate project folder structure and starter files
+- `/doit.documentit` - Organize and enhance project documentation
+- `/doit.specit` - Create feature specifications from descriptions
+- `/doit.planit` - Generate implementation plans
+- `/doit.taskit` - Break down plans into actionable tasks
+- `/doit.implementit` - Execute implementation tasks
+- `/doit.testit` - Run automated tests and generate reports
+- `/doit.reviewit` - Review code for quality and completeness
+- `/doit.checkin` - Finalize features and create pull requests
+- `/doit.roadmapit` - Create or update project roadmap
 
 The `.doit/scripts` directory will contain both `.sh` and `.ps1` scripts.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -134,7 +134,7 @@ If you need to bypass TLS validation while experimenting:
 
 ```bash
 doit check --skip-tls
-doit init demo --skip-tls --ai gemini --ignore-agent-tools --script ps
+doit init demo --skip-tls --ai claude --ignore-agent-tools --script ps
 ```
 
 (Use only for local experimentation.)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -8,20 +8,20 @@
 
 | What to Upgrade | Command | When to Use |
 |----------------|---------|-------------|
-| **CLI Tool Only** | `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git` | Get latest CLI features without touching project files |
-| **Project Files** | `specify init --here --force --ai <your-agent>` | Update slash commands, templates, and scripts in your project |
+| **CLI Tool Only** | `uv tool install doit-toolkit-cli --force` | Get latest CLI features without touching project files |
+| **Project Files** | `doit init --here --force --ai <your-agent>` | Update slash commands, templates, and scripts in your project |
 | **Both** | Run CLI upgrade, then project update | Recommended for major version updates |
 
 ---
 
 ## Part 1: Upgrade the CLI Tool
 
-The CLI tool (`specify`) is separate from your project files. Upgrade it to get the latest features and bug fixes.
+The CLI tool (`doit`) is separate from your project files. Upgrade it to get the latest features and bug fixes.
 
 ### If you installed with `uv tool install`
 
 ```bash
-uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git
+uv tool install doit-toolkit-cli --force
 ```
 
 ### If you use one-shot `uvx` commands
@@ -29,13 +29,13 @@ uv tool install specify-cli --force --from git+https://github.com/github/spec-ki
 No upgrade needed—`uvx` always fetches the latest version. Just run your commands as normal:
 
 ```bash
-uvx --from git+https://github.com/github/spec-kit.git specify init --here --ai copilot
+uvx doit-toolkit-cli init --here --ai copilot
 ```
 
 ### Verify the upgrade
 
 ```bash
-specify check
+doit check
 ```
 
 This shows installed tools and confirms the CLI is working.
@@ -48,7 +48,7 @@ When Doit releases new features (like new slash commands or updated templates), 
 
 ### What gets updated?
 
-Running `specify init --here --force` will update:
+Running `doit init --here --force` will update:
 
 - ✅ **Slash command files** (`.claude/commands/`, `.github/prompts/`, etc.)
 - ✅ **Script files** (`.doit/scripts/`)
@@ -71,7 +71,7 @@ The `specs/` directory is completely excluded from template packages and will ne
 Run this inside your project directory:
 
 ```bash
-specify init --here --force --ai <your-agent>
+doit init --here --force --ai <your-agent>
 ```
 
 Replace `<your-agent>` with your AI assistant. Refer to this list of [Supported AI Agents](../README.md#-supported-ai-agents)
@@ -79,7 +79,7 @@ Replace `<your-agent>` with your AI assistant. Refer to this list of [Supported 
 **Example:**
 
 ```bash
-specify init --here --force --ai copilot
+doit init --here --force --ai copilot
 ```
 
 ### Understanding the `--force` flag
@@ -102,7 +102,7 @@ With `--force`, it skips the confirmation and proceeds immediately.
 
 ### 1. Constitution file will be overwritten
 
-**Known issue:** `specify init --here --force` currently overwrites `.doit/memory/constitution.md` with the default template, erasing any customizations you made.
+**Known issue:** `doit init --here --force` currently overwrites `.doit/memory/constitution.md` with the default template, erasing any customizations you made.
 
 **Workaround:**
 
@@ -111,7 +111,7 @@ With `--force`, it skips the confirmation and proceeds immediately.
 cp .doit/memory/constitution.md .doit/memory/constitution-backup.md
 
 # 2. Run the upgrade
-specify init --here --force --ai copilot
+doit init --here --force --ai copilot
 
 # 3. Restore your customized constitution
 mv .doit/memory/constitution-backup.md .doit/memory/constitution.md
@@ -151,7 +151,7 @@ cd .kilocode/rules/
 ls -la
 
 # Delete old versions (example filenames - yours may differ)
-rm doit.specify-old.md
+rm doit.old-command.md
 rm doit.plan-v1.md
 ```
 
@@ -165,10 +165,10 @@ Restart your IDE to refresh the command list.
 
 ```bash
 # Upgrade CLI (if using persistent install)
-uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git
+uv tool install doit-toolkit-cli --force --from doit-toolkit-cli
 
 # Update project files to get new commands
-specify init --here --force --ai copilot
+doit init --here --force --ai copilot
 
 # Restore your constitution if customized
 git restore .doit/memory/constitution.md
@@ -182,10 +182,10 @@ cp .doit/memory/constitution.md /tmp/constitution-backup.md
 cp -r .doit/templates /tmp/templates-backup
 
 # 2. Upgrade CLI
-uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git
+uv tool install doit-toolkit-cli --force --from doit-toolkit-cli
 
 # 3. Update project
-specify init --here --force --ai copilot
+doit init --here --force --ai copilot
 
 # 4. Restore customizations
 mv /tmp/constitution-backup.md .doit/memory/constitution.md
@@ -218,7 +218,7 @@ If you initialized your project with `--no-git`, you can still upgrade:
 cp .doit/memory/constitution.md /tmp/constitution-backup.md
 
 # Run upgrade
-specify init --here --force --ai copilot --no-git
+doit init --here --force --ai copilot --no-git
 
 # Restore customizations
 mv /tmp/constitution-backup.md .doit/memory/constitution.md
@@ -239,13 +239,13 @@ The `--no-git` flag tells Doit to **skip git repository initialization**. This i
 **During initial setup:**
 
 ```bash
-specify init my-project --ai copilot --no-git
+doit init my-project --ai copilot --no-git
 ```
 
 **During upgrade:**
 
 ```bash
-specify init --here --force --ai copilot --no-git
+doit init --here --force --ai copilot --no-git
 ```
 
 ### What `--no-git` does NOT do
@@ -260,14 +260,14 @@ It **only** skips running `git init` and creating the initial commit.
 
 If you use `--no-git`, you'll need to manage feature directories manually:
 
-**Set the `SPECIFY_FEATURE` environment variable** before using planning commands:
+**Set the `DOIT_FEATURE` environment variable** before using planning commands:
 
 ```bash
 # Bash/Zsh
-export SPECIFY_FEATURE="001-my-feature"
+export DOIT_FEATURE="001-my-feature"
 
 # PowerShell
-$env:SPECIFY_FEATURE = "001-my-feature"
+$env:DOIT_FEATURE = "001-my-feature"
 ```
 
 This tells Doit which feature directory to use when creating specs, plans, and tasks.
@@ -289,8 +289,7 @@ This tells Doit which feature directory to use when creating specs, plans, and t
 
    ```bash
    ls -la .claude/commands/      # Claude Code
-   ls -la .gemini/commands/       # Gemini
-   ls -la .cursor/commands/       # Cursor
+   ls -la .github/prompts/       # GitHub Copilot
    ```
 
 3. **Check agent-specific setup:**
@@ -323,7 +322,7 @@ Do you want to continue? [y/N]
 
 **What this means:**
 
-This warning appears when you run `specify init --here` (or `specify init .`) in a directory that already has files. It's telling you:
+This warning appears when you run `doit init --here` (or `doit init .`) in a directory that already has files. It's telling you:
 
 1. **The directory has existing content** - In the example, 25 files/folders
 2. **Files will be merged** - New template files will be added alongside your existing files
@@ -352,7 +351,7 @@ Only Doit infrastructure files:
 - **Use `--force` flag** - Skip this confirmation entirely:
 
   ```bash
-  specify init --here --force --ai copilot
+  doit init --here --force --ai copilot
   ```
 
 **When you see this warning:**
@@ -371,10 +370,10 @@ Verify the installation:
 # Check installed tools
 uv tool list
 
-# Should show specify-cli
+# Should show doit-toolkit-cli
 
 # Verify path
-which specify
+which doit
 
 # Should point to the uv tool installation directory
 ```
@@ -382,23 +381,23 @@ which specify
 If not found, reinstall:
 
 ```bash
-uv tool uninstall specify-cli
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+uv tool uninstall doit-toolkit-cli
+uv tool install doit-toolkit-cli --from doit-toolkit-cli
 ```
 
-### "Do I need to run specify every time I open my project?"
+### "Do I need to run doit every time I open my project?"
 
-**Short answer:** No, you only run `specify init` once per project (or when upgrading).
+**Short answer:** No, you only run `doit init` once per project (or when upgrading).
 
 **Explanation:**
 
-The `specify` CLI tool is used for:
+The `doit` CLI tool is used for:
 
-- **Initial setup:** `specify init` to bootstrap Doit in your project
-- **Upgrades:** `specify init --here --force` to update templates and commands
-- **Diagnostics:** `specify check` to verify tool installation
+- **Initial setup:** `doit init` to bootstrap Doit in your project
+- **Upgrades:** `doit init --here --force` to update templates and commands
+- **Diagnostics:** `doit check` to verify tool installation
 
-Once you've run `specify init`, the slash commands (like `/doit.doit`, `/doit.planit`, etc.) are **permanently installed** in your project's agent folder (`.claude/`, `.github/prompts/`, etc.). Your AI assistant reads these command files directly—no need to run `specify` again.
+Once you've run `doit init`, the slash commands (like `/doit.doit`, `/doit.planit`, etc.) are **permanently installed** in your project's agent folder (`.claude/`, `.github/prompts/`, etc.). Your AI assistant reads these command files directly—no need to run `doit` again.
 
 **If your agent isn't recognizing slash commands:**
 
@@ -414,11 +413,11 @@ Once you've run `specify init`, the slash commands (like `/doit.doit`, `/doit.pl
 
 2. **Restart your IDE/editor completely** (not just reload window)
 
-3. **Check you're in the correct directory** where you ran `specify init`
+3. **Check you're in the correct directory** where you ran `doit init`
 
 4. **For some agents**, you may need to reload the workspace or clear cache
 
-**Related issue:** If Copilot can't open local files or uses PowerShell commands unexpectedly, this is typically an IDE context issue, not related to `specify`. Try:
+**Related issue:** If Copilot can't open local files or uses PowerShell commands unexpectedly, this is typically an IDE context issue, not related to `doit`. Try:
 
 - Restarting VS Code
 - Checking file permissions
@@ -439,6 +438,6 @@ Doit follows semantic versioning for major releases. The CLI and project files a
 After upgrading:
 
 - **Test new slash commands:** Run `/doit.constitution` or another command to verify everything works
-- **Review release notes:** Check [GitHub Releases](https://github.com/github/spec-kit/releases) for new features and breaking changes
+- **Review release notes:** Check [GitHub Releases](https://github.com/seanbarlow/doit/releases) for new features and breaking changes
 - **Update workflows:** If new commands were added, update your team's development workflows
-- **Check documentation:** Visit [github.io/spec-kit](https://github.github.io/spec-kit/) for updated guides
+- **Check documentation:** Visit [seanbarlow.github.io/doit](https://seanbarlow.github.io/doit/) for updated guides


### PR DESCRIPTION
## Summary

Clean up all documentation files to remove legacy "Spec Kit" and "specify" branding references, replacing them with correct "DoIt" and "doit" branding. Updated all AI agent references to reflect the officially supported agents: Claude and GitHub Copilot only.

## Changes

- Replace all "Spec Kit" and "spec-kit" with "DoIt" and "doit" in documentation
- Replace "specify-cli" with "doit-toolkit-cli" throughout docs
- Update docfx.json metadata (_appTitle, _appName, _appFooter) to reference DoIt
- Update all GitHub URLs from github/spec-kit to seanbarlow/doit
- Remove Gemini and Codebuddy from supported AI agents list
- Update installation.md to list all 11 doit commands
- Add feature documentation for 015-docs-branding-cleanup

## Testing

- [x] Automated tests pass (N/A - documentation only)
- [x] Manual testing complete (11/11 tests passed)
- [x] Code review approved

## Requirements

| ID | Description | Status |
|----|-------------|--------|
| FR-001 | Replace "Spec Kit" with "DoIt" | Done |
| FR-002 | Replace "spec-kit" with "doit" | Done |
| FR-003 | Replace "specify" CLI command with "doit" | Done |
| FR-004 | Replace "specify-cli" with "doit-toolkit-cli" | Done |
| FR-005 | Update docfx.json metadata | Done |
| FR-006-008 | Update GitHub URLs | Done |
| FR-009-012 | Remove unsupported AI agents | Done |
| FR-013-015 | Update affected doc files | Done |

## Success Criteria

All 8 success criteria validated:
- SC-001 through SC-004: Zero legacy branding matches
- SC-005 through SC-006: Zero gemini/codebuddy matches
- SC-007: All GitHub URLs correct
- SC-008: docfx.json correct

## Related Issues

Closes #31, #32, #33, #34

---
Generated by `/doit.checkin`