### PR TITLE
feat(branching): implement develop branch as default integration branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Thank you for considering contributing to DoIt! We appreciate your interest in m
 # Then clone your fork
 git clone https://github.com/YOUR-USERNAME/doit.git
 cd doit
+# You'll be on the 'develop' branch by default
 ```
 
 ### 2. Set Up Development Environment
@@ -37,7 +38,7 @@ pip install -e ".[dev]"
 We use numbered feature branches for tracking:
 
 ```bash
-git checkout -b ###-feature-name
+git checkout -b ###-feature-name develop
 ```
 
 Branch naming convention:
@@ -264,7 +265,7 @@ Who benefits? What problems does it solve?
 
 ## Pull Request Process
 
-1. **Create Branch** - From latest `main` using numbered convention
+1. **Create Branch** - From latest `develop` using numbered convention
 2. **Make Changes** - Include tests where applicable
 3. **Run Tests** - `pytest` passes locally
 4. **Commit** - Follow conventional commits
@@ -290,6 +291,40 @@ Brief description of changes.
 ## Related Issues
 Closes #123
 ```
+
+## Release Process (Maintainers)
+
+This project uses a two-branch workflow:
+
+- **`develop`** - Default branch for feature integration
+- **`main`** - Production-ready releases only
+
+### Releasing to Production
+
+1. Ensure all desired features are merged to `develop`
+2. Create a PR from `develop` to `main`:
+
+   ```bash
+   gh pr create --base main --head develop --title "Release vX.Y.Z"
+   ```
+
+3. Review and merge the PR
+4. Tag the release:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+### Hotfix Process
+
+For urgent production fixes:
+
+1. Branch from `main`: `git checkout -b hotfix-description main`
+2. Make the fix and create PR to `main`
+3. After merging to `main`, also merge or cherry-pick to `develop`
 
 ## Project Structure
 

--- a/docs/features/018-develop-branch-setup.md
+++ b/docs/features/018-develop-branch-setup.md
@@ -1,0 +1,82 @@
+# Develop Branch Setup
+
+**Completed**: 2026-01-13
+**Branch**: 018-develop-branch-setup
+**PR**: #75
+
+## Overview
+
+Implemented a Gitflow-inspired branching strategy for the DoIt project by creating a `develop` branch as the default integration branch. The `main` branch is now reserved for production-ready releases, while `develop` serves as the primary target for feature branch merges.
+
+## Requirements Implemented
+
+| ID | Description | Status |
+|----|-------------|--------|
+| FR-001 | Create develop branch from main | Done |
+| FR-002 | Set develop as default branch in GitHub | Done |
+| FR-003 | Configure branch protection for develop (PR reviews required) | Done |
+| FR-004 | Prevent direct pushes to develop | Done |
+| FR-005 | Update documentation to reflect new workflow | Done |
+| FR-006 | Retain existing main branch protection rules | Done |
+| FR-007 | Update CONTRIBUTING.md with new branching instructions | Done |
+
+## Technical Details
+
+This feature is a DevOps/infrastructure change with no code modifications:
+
+- **Branch creation**: `develop` branch created from `main` at commit 0c9f8e3
+- **Default branch**: Changed from `main` to `develop` via GitHub API
+- **Branch protection**: Configured via GitHub API with identical rules to `main`:
+  - Required PR reviews: 1
+  - Dismiss stale reviews: enabled
+  - Force pushes: disabled
+  - Branch deletions: disabled
+
+### Branching Strategy
+
+```
+main      <- Production releases only (PyPI publishes)
+  |
+develop   <- Default branch, feature integration (DEFAULT)
+  |
+  +-- ###-feature-name  <- Feature branches
+```
+
+## Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `CONTRIBUTING.md` | Modified | Updated branch workflow instructions |
+
+### CONTRIBUTING.md Changes
+
+- Quick Start: Added note about landing on `develop` by default
+- Feature branch creation: Changed `git checkout -b ###-feature-name` to `git checkout -b ###-feature-name develop`
+- PR Process: Changed target from `main` to `develop`
+- Added "Release Process (Maintainers)" section with production release and hotfix workflows
+
+## Testing
+
+- **Automated tests**: N/A (DevOps/infrastructure feature)
+- **Manual verification**: 5/5 passed
+  - Clone default branch verification: `develop` confirmed
+  - GitHub UI default branch: `develop` confirmed
+  - Branch protection rules: configured and verified
+  - Feature branch workflow: tested successfully
+  - Release workflow: documented and verified possible
+
+## Success Criteria Verification
+
+| Criteria | Verification |
+|----------|--------------|
+| SC-001: Clone lands on develop | Verified via `git clone` test |
+| SC-002: PRs target develop by default | Verified via GitHub API |
+| SC-003: Direct push to develop rejected | Verified via protection rules |
+| SC-004: Documentation updated | CONTRIBUTING.md updated |
+| SC-005: Both branches have protection | Both verified via GitHub API |
+
+## Related Issues
+
+- Epic: #57
+- Features: #58, #59, #60
+- Tasks: #61, #62, #63, #64, #65, #66, #67, #68, #69, #70, #71, #72, #73, #74


### PR DESCRIPTION
## Summary

Implements a Gitflow-inspired branching strategy for the DoIt project by creating a `develop` branch as the default integration branch. The `main` branch is now reserved for production-ready releases.

## Changes

- Created `develop` branch from `main`
- Set `develop` as the default branch in GitHub repository settings
- Configured branch protection rules for `develop` (1 required review, dismiss stale, no force push)
- Updated `CONTRIBUTING.md` with new branching workflow:
  - Feature branches now created from `develop`
  - PRs now target `develop` by default
  - Added "Release Process (Maintainers)" section
- Created feature documentation

## Testing

- [x] Clone lands on develop branch
- [x] GitHub UI shows develop as default
- [x] Branch protection rules configured
- [x] Feature branch workflow verified
- [x] Release workflow documented

## Requirements

| ID | Description | Status |
|----|-------------|--------|
| FR-001 | Create develop branch from main | Done |
| FR-002 | Set develop as default branch | Done |
| FR-003 | Configure branch protection for develop | Done |
| FR-004 | Prevent direct pushes to develop | Done |
| FR-005 | Update documentation | Done |
| FR-006 | Retain main branch protection | Done |
| FR-007 | Update CONTRIBUTING.md | Done |

## Related Issues

Closes #57, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67, #68, #69, #70, #71, #72, #73

---
Generated by `/doit.checkin`