### PR TITLE
chore(release): Bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doit-toolkit-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "Doit CLI - A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Update pyproject.toml version to 0.1.3 to match release tag

## Context
The v0.1.3 release workflow failed because pyproject.toml still had version 0.1.2.
This PR updates the version to allow PyPI publish to succeed.

## Test plan
- [ ] Version in pyproject.toml matches release tag v0.1.3
- [ ] PyPI publish workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)