### PR TITLE
fix: remove "$@" from hook templates to prevent argument mismatch

### DIFF
--- a/templates/hooks/pre-commit.sh
+++ b/templates/hooks/pre-commit.sh
@@ -13,4 +13,5 @@ if ! command -v doit &> /dev/null; then
 fi
 
 # Run pre-commit validation
-exec doit hooks validate pre-commit "$@"
+# Note: The doit validate command only needs the hook type, not shell arguments.
+exec doit hooks validate pre-commit

--- a/templates/hooks/pre-push.sh
+++ b/templates/hooks/pre-push.sh
@@ -13,4 +13,6 @@ if ! command -v doit &> /dev/null; then
 fi
 
 # Run pre-push validation
-exec doit hooks validate pre-push "$@"
+# Note: Git passes remote name and URL as arguments, and ref info via stdin.
+# The doit validate command only needs the hook type, not git's arguments.
+exec doit hooks validate pre-push


### PR DESCRIPTION
## Summary
- Fixed pre-push hook failing with "Got unexpected extra arguments" when pushing to remote
- Removed `"$@"` from both `pre-push.sh` and `pre-commit.sh` hook templates
- The `doit hooks validate` command only expects a single `hook_type` argument, not git's CLI arguments

## Root Cause
Git's pre-push hook receives `<remote-name> <remote-url>` as command-line arguments. The hook templates were forwarding these to `doit hooks validate pre-push "$@"`, causing the CLI to reject the extra arguments.

## Test plan
- [x] All 449 tests pass
- [x] Manually verified the fix addresses the error described in #374

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)