### PR TITLE
fix(init): use dot format for Copilot prompt filenames (#544)

### DIFF
--- a/.doit/state/fixit-544.json
+++ b/.doit/state/fixit-544.json
@@ -1,0 +1,149 @@
+{
+  "issue_id": 544,
+  "title": "[Bug]: doit init",
+  "phase": "implementing",
+  "branch": "fix/544-copilot-prompt-filename",
+  "created_at": "2026-01-20T17:41:55Z",
+  "updated_at": "2026-01-20T19:15:00Z",
+  "issue_summary": {
+    "description": "When running doit init, it creates GitHub Copilot prompts with incorrect naming: doit-fixit.prompt.md instead of doit.fixit.prompt.md",
+    "steps_to_reproduce": [
+      "Run doit init .",
+      "Review the file names generated in .github/prompts/"
+    ],
+    "expected_behavior": "Files should be named doit.fixit.prompt.md (dots, not hyphens)",
+    "environment": "macOS 14, Python 3.13"
+  },
+  "investigation": {
+    "checkpoints": [
+      {
+        "id": "cp-1",
+        "description": "Review error logs and stack traces",
+        "status": "completed",
+        "notes": "No error - this is a naming convention inconsistency, not an exception"
+      },
+      {
+        "id": "cp-2",
+        "description": "Identify affected code paths",
+        "status": "completed",
+        "notes": "Found in 6 files: template.py, template_manager.py, agent.py, scaffolder.py, agent_detector.py, validator.py"
+      },
+      {
+        "id": "cp-3",
+        "description": "Search for related issues or commits",
+        "status": "completed",
+        "notes": "sync_models.py uses correct format (dots). Existing .github/prompts/ files use correct format. Old code uses wrong format (hyphens)."
+      },
+      {
+        "id": "cp-4",
+        "description": "Formulate root cause hypothesis",
+        "status": "completed",
+        "notes": "Root cause confirmed - see confirmed_cause finding"
+      }
+    ],
+    "findings": [
+      {
+        "id": "f-1",
+        "type": "reproduction_step",
+        "description": "Run 'doit init . --copilot' and check .github/prompts/ - files would be generated with doit-{name}.prompt.md format"
+      },
+      {
+        "id": "f-2",
+        "type": "affected_file",
+        "description": "src/doit_cli/models/template.py:47 - returns f\"doit-{self.name}.prompt.md\" for COPILOT"
+      },
+      {
+        "id": "f-3",
+        "type": "affected_file",
+        "description": "src/doit_cli/models/template.py:60-61 - parses filename using doit- prefix"
+      },
+      {
+        "id": "f-4",
+        "type": "affected_file",
+        "description": "src/doit_cli/models/agent.py:63 - file_pattern uses \"doit-*.prompt.md\""
+      },
+      {
+        "id": "f-5",
+        "type": "affected_file",
+        "description": "src/doit_cli/services/template_manager.py:300 - generates f\"doit-{template.name}.prompt.md\""
+      },
+      {
+        "id": "f-6",
+        "type": "affected_file",
+        "description": "src/doit_cli/services/scaffolder.py:120 - checks startswith(\"doit-\")"
+      },
+      {
+        "id": "f-7",
+        "type": "affected_file",
+        "description": "src/doit_cli/services/agent_detector.py:139,165 - checks startswith(\"doit-\")"
+      },
+      {
+        "id": "f-8",
+        "type": "affected_file",
+        "description": "src/doit_cli/services/validator.py:95 - expects f\"doit-{cmd}.prompt.md\""
+      },
+      {
+        "id": "f-9",
+        "type": "confirmed_cause",
+        "description": "Naming convention inconsistency: Old code (template.py, agent.py, template_manager.py, scaffolder.py, agent_detector.py, validator.py) uses hyphen format (doit-fixit.prompt.md), but newer code (sync_models.py) and existing files in .github/prompts/ use dot format (doit.fixit.prompt.md). The hyphen format was an older convention that should be replaced with the dot format to match Claude commands (doit.fixit.md) for consistency."
+      }
+    ],
+    "keywords": ["init", "copilot", "prompt", "filename", "doit-fixit", "doit.fixit", "naming", "hyphen", "dot"]
+  },
+  "plan": {
+    "root_cause_summary": "Old code uses hyphen format (doit-fixit.prompt.md) for Copilot prompt filenames, but newer code and existing files use dot format (doit.fixit.prompt.md). This creates inconsistency when doit init generates new files.",
+    "proposed_solution": "Update all 6 affected files to use the dot format (doit.{name}.prompt.md) instead of the hyphen format (doit-{name}.prompt.md). This aligns Copilot prompts with the Claude command naming convention (doit.{name}.md) for consistency.",
+    "files_to_modify": [
+      {
+        "path": "src/doit_cli/models/template.py",
+        "change": "Line 47: Change f\"doit-{self.name}.prompt.md\" to f\"doit.{self.name}.prompt.md\"; Lines 60-61: Change doit- to doit. for parsing"
+      },
+      {
+        "path": "src/doit_cli/models/agent.py",
+        "change": "Line 63: Change \"doit-*.prompt.md\" to \"doit.*.prompt.md\""
+      },
+      {
+        "path": "src/doit_cli/services/template_manager.py",
+        "change": "Line 300: Change f\"doit-{template.name}.prompt.md\" to f\"doit.{template.name}.prompt.md\""
+      },
+      {
+        "path": "src/doit_cli/services/scaffolder.py",
+        "change": "Line 120: Change startswith(\"doit-\") to startswith(\"doit.\")"
+      },
+      {
+        "path": "src/doit_cli/services/agent_detector.py",
+        "change": "Lines 139, 165: Change startswith(\"doit-\") to startswith(\"doit.\")"
+      },
+      {
+        "path": "src/doit_cli/services/validator.py",
+        "change": "Line 95: Change f\"doit-{cmd}.prompt.md\" to f\"doit.{cmd}.prompt.md\""
+      }
+    ],
+    "risk_assessment": "low",
+    "risk_notes": "Low risk - string constant updates only. All changes are consistent with existing newer code (sync_models.py) and existing files. No logic changes required.",
+    "testing_strategy": [
+      "Run existing tests to ensure no regressions",
+      "Verify doit init --copilot creates files with doit.{name}.prompt.md format",
+      "Verify existing .github/prompts/ files are detected correctly"
+    ],
+    "approved": true,
+    "approved_at": "2026-01-20T18:50:00Z"
+  },
+  "implementation": {
+    "status": "completed",
+    "completed_at": "2026-01-20T19:15:00Z",
+    "files_modified": [
+      "src/doit_cli/models/template.py",
+      "src/doit_cli/models/agent.py",
+      "src/doit_cli/services/template_manager.py",
+      "src/doit_cli/services/scaffolder.py",
+      "src/doit_cli/services/agent_detector.py",
+      "src/doit_cli/services/validator.py",
+      "tests/unit/test_agent.py",
+      "tests/unit/test_template_manager.py"
+    ],
+    "tests_passed": true,
+    "tests_count": 1026,
+    "notes": "Updated all 6 source files and 2 test files to use doit.{name}.prompt.md format. All 1026 tests pass."
+  }
+}

--- a/src/doit_cli/models/agent.py
+++ b/src/doit_cli/models/agent.py
@@ -60,7 +60,7 @@ class Agent(str, Enum):
         """Glob pattern for doit-managed files."""
         patterns = {
             Agent.CLAUDE: "doit.*.md",
-            Agent.COPILOT: "doit-*.prompt.md",
+            Agent.COPILOT: "doit.*.prompt.md",
         }
         return patterns[self]
 
@@ -69,6 +69,6 @@ class Agent(str, Enum):
         """Filename prefix for doit commands."""
         prefixes = {
             Agent.CLAUDE: "doit.",
-            Agent.COPILOT: "doit-",
+            Agent.COPILOT: "doit.",
         }
         return prefixes[self]

--- a/src/doit_cli/models/template.py
+++ b/src/doit_cli/models/template.py
@@ -44,7 +44,7 @@ class Template:
         if self.agent == Agent.CLAUDE:
             return f"doit.{self.name}.md"
         else:  # COPILOT
-            return f"doit-{self.name}.prompt.md"
+            return f"doit.{self.name}.prompt.md"
 
     @classmethod
     def from_file(cls, path: Path, agent: Agent) -> "Template":
@@ -57,8 +57,8 @@ class Template:
             # doit.specit.md -> specit
             name = filename.replace("doit.", "").replace(".md", "")
         else:  # COPILOT
-            # doit-specit.prompt.md -> specit
-            name = filename.replace("doit-", "").replace(".prompt.md", "")
+            # doit.specit.prompt.md -> specit
+            name = filename.replace("doit.", "").replace(".prompt.md", "")
 
         return cls(name=name, agent=agent, source_path=path, content=content)
 

--- a/src/doit_cli/services/agent_detector.py
+++ b/src/doit_cli/services/agent_detector.py
@@ -136,7 +136,7 @@ class AgentDetector:
                     if file.name.startswith("doit.") and file.name.endswith(".md"):
                         return True
                 else:  # COPILOT
-                    if file.name.startswith("doit-") and file.name.endswith(".prompt.md"):
+                    if file.name.startswith("doit.") and file.name.endswith(".prompt.md"):
                         return True
 
         return False
@@ -162,7 +162,7 @@ class AgentDetector:
                     if file.name.startswith("doit.") and file.name.endswith(".md"):
                         count += 1
                 else:  # COPILOT
-                    if file.name.startswith("doit-") and file.name.endswith(".prompt.md"):
+                    if file.name.startswith("doit.") and file.name.endswith(".prompt.md"):
                         count += 1
 
         return count

--- a/src/doit_cli/services/scaffolder.py
+++ b/src/doit_cli/services/scaffolder.py
@@ -117,7 +117,7 @@ class Scaffolder:
         if agent == Agent.CLAUDE:
             return filename.startswith("doit.") and filename.endswith(".md")
         else:  # COPILOT
-            return filename.startswith("doit-") and filename.endswith(".prompt.md")
+            return filename.startswith("doit.") and filename.endswith(".prompt.md")
 
     def get_doit_files(self, agent: Agent) -> list[Path]:
         """Get all doit-managed files for an agent.

--- a/src/doit_cli/services/template_manager.py
+++ b/src/doit_cli/services/template_manager.py
@@ -296,8 +296,8 @@ class TemplateManager:
             # Transform the content
             transformed_content = transformer.transform(command_template)
 
-            # Generate Copilot filename: doit-{name}.prompt.md
-            target_filename = f"doit-{template.name}.prompt.md"
+            # Generate Copilot filename: doit.{name}.prompt.md
+            target_filename = f"doit.{template.name}.prompt.md"
             target_path = target_dir / target_filename
 
             if target_path.exists():

--- a/src/doit_cli/services/validator.py
+++ b/src/doit_cli/services/validator.py
@@ -92,7 +92,7 @@ class Validator:
         if agent == Agent.CLAUDE:
             expected_files = {f"doit.{cmd}.md" for cmd in DOIT_COMMANDS}
         else:  # COPILOT
-            expected_files = {f"doit-{cmd}.prompt.md" for cmd in DOIT_COMMANDS}
+            expected_files = {f"doit.{cmd}.prompt.md" for cmd in DOIT_COMMANDS}
 
         # Get actual files
         actual_files = {f.name for f in cmd_dir.iterdir() if f.is_file()}

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -38,7 +38,7 @@ class TestAgentProperties:
 
     def test_copilot_file_pattern(self):
         """Test Copilot file pattern."""
-        assert Agent.COPILOT.file_pattern == "doit-*.prompt.md"
+        assert Agent.COPILOT.file_pattern == "doit.*.prompt.md"
 
     def test_claude_file_prefix(self):
         """Test Claude file prefix."""
@@ -46,7 +46,7 @@ class TestAgentProperties:
 
     def test_copilot_file_prefix(self):
         """Test Copilot file prefix."""
-        assert Agent.COPILOT.file_prefix == "doit-"
+        assert Agent.COPILOT.file_prefix == "doit."
 
 
 class TestTemplateDirectory:

--- a/tests/unit/test_template_manager.py
+++ b/tests/unit/test_template_manager.py
@@ -398,7 +398,7 @@ class TestUnifiedTemplates:
 
         # Files should have Copilot naming convention
         for path in result["created"]:
-            assert path.name.startswith("doit-")
+            assert path.name.startswith("doit.")
             assert path.name.endswith(".prompt.md")
 
     def test_copilot_templates_are_transformed(self, temp_dir):
@@ -447,11 +447,11 @@ class TestUnifiedTemplates:
         templates = manager._get_command_templates()
         result = manager._transform_and_write_templates(templates, target_dir)
 
-        # Each created file should match doit-{name}.prompt.md pattern
+        # Each created file should match doit.{name}.prompt.md pattern
         for path in result["created"]:
             filename = path.name
-            assert filename.startswith("doit-")
+            assert filename.startswith("doit.")
             assert filename.endswith(".prompt.md")
             # Extract name and verify it's valid
-            name = filename.replace("doit-", "").replace(".prompt.md", "")
+            name = filename.replace("doit.", "").replace(".prompt.md", "")
             assert name in DOIT_COMMANDS


### PR DESCRIPTION
## Summary

Fixes issue where `doit init` creates GitHub Copilot prompts with incorrect naming convention (`doit-fixit.prompt.md` instead of `doit.fixit.prompt.md`).

## Root Cause

Old code used hyphen format (`doit-{name}.prompt.md`) while newer code and existing files use dot format (`doit.{name}.prompt.md`). This creates inconsistency when generating new files.

## Changes

- **template.py**: Changed filename generation from `doit-{name}.prompt.md` to `doit.{name}.prompt.md`
- **agent.py**: Updated `file_pattern` to `doit.*.prompt.md` and `file_prefix` to `doit.`
- **template_manager.py**: Updated target filename generation
- **scaffolder.py**: Updated `startswith()` check from `doit-` to `doit.`
- **agent_detector.py**: Updated prefix checks (lines 139, 165)
- **validator.py**: Updated expected filename format

## Testing

- [x] All 1026 existing tests pass
- [x] Updated test assertions to expect new format

## Files Changed

| File | Change |
|------|--------|
| `src/doit_cli/models/template.py` | Filename generation/parsing |
| `src/doit_cli/models/agent.py` | file_pattern and file_prefix |
| `src/doit_cli/services/template_manager.py` | Target filename |
| `src/doit_cli/services/scaffolder.py` | Prefix check |
| `src/doit_cli/services/agent_detector.py` | Prefix checks |
| `src/doit_cli/services/validator.py` | Expected format |
| `tests/unit/test_agent.py` | Updated assertions |
| `tests/unit/test_template_manager.py` | Updated assertions |

Fixes #544

---
Generated by `/doit.checkin`