### PR TITLE
fix(build): include doit_toolkit_cli package in wheel distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/doit_cli"]
+packages = ["src/doit_cli", "src/doit_toolkit_cli"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Fixes the CLI error caused by `ModuleNotFoundError: No module named 'doit_toolkit_cli'` when running any doit command after installation.

## Root Cause

The `pyproject.toml` build configuration only included `src/doit_cli` in the wheel package, but `doit_cli` imports from `doit_toolkit_cli` which was not being packaged.

## Changes

- Added `src/doit_toolkit_cli` to the packages list in `[tool.hatch.build.targets.wheel]` section

## Testing

- [x] Built wheel successfully
- [x] Verified wheel contains both `doit_cli` and `doit_toolkit_cli` packages
- [x] All 1327 tests pass

## Verification

```bash
# Build
uv build

# Verify package contents
unzip -l dist/*.whl | grep doit_toolkit_cli
# Shows doit_toolkit_cli/* files included
```

Fixes #598

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)