### PR TITLE
Release v0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doit-toolkit-cli"
-version = "0.1.10"
+version = "0.1.11"
 description = "Doit CLI - A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Release v0.1.11 with bug fix for CLI error.

## Changes

- **fix(build)**: Include `doit_toolkit_cli` package in wheel distribution (#599)
  - Fixed `ModuleNotFoundError: No module named 'doit_toolkit_cli'` when running any doit command

## Release Checklist

- [x] Bug fix merged (#599)
- [x] Version bumped to 0.1.11
- [x] All tests passing (1327 tests)
- [ ] PR merged to main
- [ ] Tag `v0.1.11` created (triggers PyPI publish)

## After Merge

Create the release tag to trigger PyPI publish:
```bash
git checkout main && git pull
git tag v0.1.11
git push origin v0.1.11
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)