### PR TITLE
feat(providers): implement git provider abstraction layer

### DIFF
--- a/.doit/memory/completed_roadmap.md
+++ b/.doit/memory/completed_roadmap.md
@@ -12,6 +12,7 @@
 
 | Item | Original Priority | Completed Date | Feature Branch | Notes |
 |------|-------------------|----------------|----------------|-------|
+| Git provider abstraction layer | P2 | 2026-01-22 | `044-git-provider-abstraction` | Unified interface for GitHub/Azure DevOps/GitLab, provider auto-detection from git remote, 31 tasks (100% complete), full GitHub+ADO implementation, GitLab stub |
 | Unified CLI package consolidation | P2 | 2026-01-22 | `043-unified-cli` | Merged doit_toolkit_cli into doit_cli, single package structure, 17 files migrated, github_service.py merged, 1345 tests pass, cleaner imports |
 | Team collaboration features (shared memory, notifications) | P4 | 2026-01-22 | `042-team-collaboration` | Git-based sync for constitution/roadmap, change notifications via watchdog, conflict resolution UI, access control (read-only/read-write), 28 tasks (100% complete), 18 integration tests passed |
 | GitHub Milestone Generation from Priorities | P3 | 2026-01-22 | `041-milestone-generation` | Auto-create GitHub milestones for priority levels (P1-P4), assign epics to milestones, close completed milestones, --dry-run support, 21 tasks (100% complete), 1,327 tests passed |
@@ -31,9 +32,7 @@
 | Interactive guided workflows with validation | P2 | 2026-01-16 | `030-guided-workflows` | Step-by-step guidance, validation, progress display, workflow recovery |
 | Spec validation and linting | P2 | 2026-01-15 | `029-spec-validation-linting` | Validate command with 10 rules, quality scoring, pre-commit hooks, custom rules |
 | AI context injection for commands | P2 | 2026-01-15 | `026-ai-context-injection`, `027-template-context-injection` | Auto-load constitution, roadmap, related specs into command execution |
-| Git hook integration for workflow enforcement | P2 | 2026-01-15 | `025-git-hooks-workflow` | Pre-commit/push hooks, spec-first validation, bypass logging |
-| Unified template management | P1 | 2026-01-15 | `024-unified-templates` | Single source of truth for commands, eliminates duplicate templates |
-| Multi-agent prompt synchronization | P1 | 2026-01-15 | `023-copilot-prompts-sync` | Consistent prompts across Claude, Copilot agents |
+
 ---
 
 ## Archive
@@ -45,6 +44,9 @@
 
 | Item | Original Priority | Completed Date | Feature Branch |
 |------|-------------------|----------------|----------------|
+| Git hook integration for workflow enforcement | P2 | 2026-01-15 | `025-git-hooks-workflow` |
+| Unified template management | P1 | 2026-01-15 | `024-unified-templates` |
+| Multi-agent prompt synchronization | P1 | 2026-01-15 | `023-copilot-prompts-sync` |
 | Core workflow commands | P1 | 2026-01-10 | — |
 
 </details>
@@ -53,9 +55,9 @@
 
 ## Statistics
 
-- **Total Items Completed**: 21
-- **P1 Items Completed**: 4 (1 archived)
-- **P2 Items Completed**: 12
+- **Total Items Completed**: 24
+- **P1 Items Completed**: 4 (4 archived)
+- **P2 Items Completed**: 14 (1 archived)
 - **P3 Items Completed**: 4
 - **P4 Items Completed**: 2
 - **Other**: 1 (documentation audit)

--- a/.doit/memory/roadmap.md
+++ b/.doit/memory/roadmap.md
@@ -1,7 +1,7 @@
 # Project Roadmap
 
 **Project**: Do-It
-**Last Updated**: 2026-01-22 (Updated: Synced completed items, released v0.1.11)
+**Last Updated**: 2026-01-22 (Added: Azure DevOps provider support)
 **Managed by**: `/doit.roadmapit`
 
 ## Vision
@@ -22,7 +22,8 @@ An AI-assisted spec-driven development CLI that streamlines the software develop
 
 <!-- Items with high business value, scheduled for near-term delivery -->
 
-✅ **All P2 items completed!** See `.doit/memory/completed_roadmap.md` for history.
+- [ ] Azure DevOps git provider support `[045-azure-devops-provider]`
+  - **Rationale**: Enable users to select Azure DevOps as an alternative to GitHub for git operations, expanding enterprise adoption and supporting teams using Microsoft's DevOps platform
 
 ### P3 - Medium Priority (Valuable)
 
@@ -54,6 +55,12 @@ An AI-assisted spec-driven development CLI that streamlines the software develop
 
 - [ ] Template diff on version updates
   - **Rationale**: Show diff view when unified templates are updated to help users understand changes
+
+- [ ] Git provider configuration wizard
+  - **Rationale**: Interactive setup wizard to configure authentication and default settings for each git provider (GitHub, Azure DevOps, GitLab)
+
+- [ ] GitLab git provider support
+  - **Rationale**: Support GitLab as a git provider option, enabling teams using GitLab for source control and CI/CD
 
 ### P4 - Low Priority (Nice to Have)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Auto-generated from all feature plans. Last updated: 2026-01-10
 - File-based YAML in `.doit/config/team.yaml`, JSON in `.doit/state/`, markdown in `.doit/memory/` (042-team-collaboration)
 - Python 3.11+ (from constitution) + Typer, Rich, httpx, pytest (from constitution) (043-unified-cli)
 - File-based markdown (no database) (043-unified-cli)
+- Python 3.11+ + Typer (CLI), Rich (output), httpx (HTTP client), pytest (testing) (044-git-provider-abstraction)
+- File-based (`.doit/config/provider.yaml` for provider settings) (044-git-provider-abstraction)
 
 - Markdown (command definitions), Bash 5.x (scripts), Python 3.11+ (CLI) + Claude Code slash command system, GitHub MCP server, typer, rich, httpx (001-doit-command-refactor)
 
@@ -78,10 +80,10 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Markdown (command definitions), Bash 5.x (scripts), Python 3.11+ (CLI): Follow standard conventions
 
 ## Recent Changes
+- 044-git-provider-abstraction: Added Python 3.11+ + Typer (CLI), Rich (output), httpx (HTTP client), pytest (testing)
 - 043-unified-cli: Added Python 3.11+ (from constitution) + Typer, Rich, httpx, pytest (from constitution)
 
 - 042-team-collaboration: Added Python 3.11+ + Typer (CLI), Rich (terminal output), PyYAML (configuration), watchdog (file monitoring)
-- 041-milestone-generation: Added Python 3.11+ + Typer (CLI), Rich (terminal output), httpx (HTTP client), pytest (testing)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/features/044-git-provider-abstraction.md
+++ b/docs/features/044-git-provider-abstraction.md
@@ -1,0 +1,321 @@
+# Feature: Git Provider Abstraction Layer
+
+**Spec**: [044-git-provider-abstraction](../../specs/044-git-provider-abstraction/spec.md)
+**Status**: Implemented
+**Completed**: 2026-01-22
+**Branch**: `044-git-provider-abstraction`
+**Version**: 0.2.0
+
+## Overview
+
+The Git Provider Abstraction Layer enables doit to work with multiple git hosting providers (GitHub, Azure DevOps, GitLab) through a unified interface. This allows CLI commands to remain provider-agnostic while supporting provider-specific behaviors through configuration.
+
+## Supported Providers
+
+| Provider | Status | Authentication |
+|----------|--------|----------------|
+| **GitHub** | ✅ Full | gh CLI (`gh auth login`) |
+| **Azure DevOps** | ✅ Full | Personal Access Token |
+| **GitLab** | ⚠️ Stub | Not yet implemented |
+
+## Quick Start
+
+### Configure Your Provider
+
+```bash
+# Auto-detect from git remote URL
+doit provider configure --auto-detect
+
+# Or explicitly select a provider
+doit provider configure --provider github
+doit provider configure --provider azure_devops -o myorg --project myproject
+```
+
+### Check Provider Status
+
+```bash
+doit provider status
+```
+
+### Provider Detection
+
+The abstraction layer automatically detects your provider from the git remote URL:
+
+| Remote URL Pattern | Detected Provider |
+|--------------------|-------------------|
+| `github.com/*` | GitHub |
+| `ghe.*/*` | GitHub Enterprise |
+| `dev.azure.com/*` | Azure DevOps |
+| `*.visualstudio.com/*` | Azure DevOps |
+| `gitlab.com/*` | GitLab |
+| `gitlab.*/*` | GitLab (self-hosted) |
+
+## Configuration
+
+Provider configuration is stored in `.doit/config/provider.yaml`:
+
+```yaml
+# GitHub (default for github.com remotes)
+provider: github
+auto_detected: true
+detection_source: git_remote
+github:
+  auth_method: gh_cli
+
+# Azure DevOps
+provider: azure_devops
+auto_detected: false
+azure_devops:
+  organization: myorg
+  project: myproject
+  auth_method: pat
+  api_version: "7.0"
+```
+
+## Authentication
+
+### GitHub
+
+GitHub authentication uses the `gh` CLI tool:
+
+```bash
+# Install gh CLI: https://cli.github.com
+gh auth login
+```
+
+### Azure DevOps
+
+Azure DevOps uses a Personal Access Token (PAT):
+
+1. Go to Azure DevOps → User Settings → Personal Access Tokens
+2. Create a token with Work Items and Code permissions
+3. Set the environment variable:
+
+```bash
+export AZURE_DEVOPS_PAT="your-token-here"
+```
+
+### GitLab (Future)
+
+GitLab will use an access token:
+
+```bash
+export GITLAB_TOKEN="your-token-here"
+```
+
+## Usage in Code
+
+### Basic Usage
+
+```python
+from doit_cli.services.provider_factory import ProviderFactory
+from doit_cli.models.provider_models import IssueCreateRequest
+
+# Create provider (auto-detected or from config)
+provider = ProviderFactory.create()
+
+# Create an issue
+issue = provider.create_issue(
+    IssueCreateRequest(
+        title="Bug: Login fails",
+        body="Steps to reproduce...",
+        labels=["bug", "priority:high"]
+    )
+)
+
+print(f"Created issue: {issue.url}")
+```
+
+### Offline-Safe Usage
+
+```python
+from doit_cli.services.provider_factory import ProviderFactory
+
+# Returns None if provider is unavailable
+provider = ProviderFactory.create_safe()
+
+if provider:
+    issues = provider.list_issues()
+else:
+    print("Running in offline mode")
+```
+
+### Backward Compatibility
+
+Existing code using `GitHubService` continues to work:
+
+```python
+from doit_cli.services.github_service import GitHubService
+
+# Existing code works unchanged
+service = GitHubService()
+epics = service.fetch_epics()
+
+# Or get the new provider for new operations
+provider = service.get_provider()
+```
+
+## Provider Interface
+
+All providers implement the `GitProvider` interface:
+
+### Issue Operations
+
+| Method | Description |
+|--------|-------------|
+| `create_issue(request)` | Create a new issue |
+| `get_issue(id)` | Get issue by ID |
+| `list_issues(filters)` | List issues with filters |
+| `update_issue(id, updates)` | Update an issue |
+
+### Pull Request Operations
+
+| Method | Description |
+|--------|-------------|
+| `create_pull_request(request)` | Create a new PR/MR |
+| `get_pull_request(id)` | Get PR by ID |
+| `list_pull_requests(filters)` | List PRs with filters |
+
+### Milestone Operations
+
+| Method | Description |
+|--------|-------------|
+| `create_milestone(request)` | Create a new milestone |
+| `get_milestone(id)` | Get milestone by ID |
+| `list_milestones(state)` | List milestones |
+
+## Data Models
+
+### Issue
+
+```python
+@dataclass
+class Issue:
+    id: str              # Unified ID: github:issue:123
+    provider_id: str     # Provider-specific: 123
+    title: str
+    body: str | None
+    state: IssueState    # OPEN, CLOSED
+    type: IssueType      # BUG, TASK, USER_STORY, FEATURE, EPIC
+    labels: list[Label]
+    url: str
+    created_at: datetime
+    updated_at: datetime
+```
+
+### PullRequest
+
+```python
+@dataclass
+class PullRequest:
+    id: str
+    provider_id: str
+    title: str
+    body: str | None
+    source_branch: str
+    target_branch: str
+    state: PRState       # OPEN, MERGED, CLOSED
+    labels: list[Label]
+    url: str
+    created_at: datetime
+    merged_at: datetime | None
+```
+
+### Milestone
+
+```python
+@dataclass
+class Milestone:
+    id: str
+    provider_id: str
+    title: str
+    description: str | None
+    state: MilestoneState  # OPEN, CLOSED
+    due_date: datetime | None
+    issue_count: int
+    closed_issue_count: int
+```
+
+## Label Translation
+
+Labels are translated between providers automatically:
+
+| Unified Type | GitHub | Azure DevOps |
+|--------------|--------|--------------|
+| BUG | `bug` | Work Item Type: Bug |
+| TASK | `task` | Work Item Type: Task |
+| USER_STORY | `enhancement` | Work Item Type: User Story |
+| FEATURE | `feature` | Work Item Type: Feature |
+| EPIC | `epic` | Work Item Type: Epic |
+
+## Error Handling
+
+The abstraction layer provides consistent error handling:
+
+```python
+from doit_cli.services.providers.exceptions import (
+    AuthenticationError,
+    RateLimitError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+try:
+    issue = provider.create_issue(request)
+except AuthenticationError:
+    print("Please authenticate with your provider")
+except RateLimitError as e:
+    print(f"Rate limited. Retry after {e.retry_after} seconds")
+except ResourceNotFoundError as e:
+    print(f"{e.resource_type} not found: {e.resource_id}")
+except ValidationError as e:
+    print(f"Invalid input: {e.message}")
+```
+
+## Rate Limiting
+
+For operations that may encounter rate limits, use the retry decorator:
+
+```python
+from doit_cli.services.providers.base import with_retry
+
+@with_retry(max_retries=3, base_delay=1.0)
+def fetch_all_issues():
+    return provider.list_issues()
+```
+
+## Related Commands
+
+- `doit provider configure` - Configure git provider
+- `doit provider status` - Show provider status
+- `doit provider detect` - Auto-detect provider
+- `doit roadmapit add` - Create epics (uses provider)
+- `doit roadmapit sync-milestones` - Sync milestones (uses provider)
+
+## Troubleshooting
+
+### "No git provider configured"
+
+Run `doit provider configure` to set up your provider.
+
+### "GitHub CLI not authenticated"
+
+Run `gh auth login` to authenticate with GitHub.
+
+### "AZURE_DEVOPS_PAT environment variable not set"
+
+Set your Azure DevOps Personal Access Token:
+
+```bash
+export AZURE_DEVOPS_PAT="your-token-here"
+```
+
+### "GitLab provider does not support X yet"
+
+GitLab support is planned for a future release. Use GitHub or Azure DevOps in the meantime.
+
+## See Also
+
+- [Specification](../../specs/044-git-provider-abstraction/spec.md)
+- [Implementation Plan](../../specs/044-git-provider-abstraction/plan.md)
+- [Data Model](../../specs/044-git-provider-abstraction/data-model.md)

--- a/specs/044-git-provider-abstraction/checklists/requirements.md
+++ b/specs/044-git-provider-abstraction/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Git Provider Abstraction Layer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Summary
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Content Quality | Pass | Spec focuses on what and why, not how |
+| Requirement Completeness | Pass | 21 FRs defined, all testable |
+| Feature Readiness | Pass | 5 user stories with acceptance scenarios |
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/doit.planit`
+- Dependencies section mentions existing code (GitHub service) but this is appropriate for planning context
+- Out of Scope section clearly bounds the feature

--- a/specs/044-git-provider-abstraction/contracts/provider_interface.py
+++ b/specs/044-git-provider-abstraction/contracts/provider_interface.py
@@ -1,0 +1,549 @@
+"""
+Git Provider Interface Contract
+
+This module defines the abstract interface that all git providers must implement.
+It serves as the contract between the doit CLI and provider implementations.
+
+Feature: 044-git-provider-abstraction
+Date: 2026-01-22
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+# =============================================================================
+# Enumerations
+# =============================================================================
+
+
+class ProviderType(Enum):
+    """Supported git provider types."""
+
+    GITHUB = "github"
+    AZURE_DEVOPS = "azure_devops"
+    GITLAB = "gitlab"
+
+
+class IssueType(Enum):
+    """Unified issue type classification."""
+
+    BUG = "bug"
+    TASK = "task"
+    USER_STORY = "user_story"
+    FEATURE = "feature"
+    EPIC = "epic"
+
+
+class IssueState(Enum):
+    """Issue state."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class PRState(Enum):
+    """Pull request state."""
+
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"
+
+
+class MilestoneState(Enum):
+    """Milestone state."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+
+@dataclass
+class Label:
+    """A label/tag that can be applied to issues and pull requests."""
+
+    name: str
+    color: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class Issue:
+    """Unified issue representation across all providers."""
+
+    id: str  # Unified ID: {provider}:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    state: IssueState
+    url: str
+    created_at: datetime
+    updated_at: datetime
+    body: str | None = None
+    type: IssueType = IssueType.TASK
+    labels: list[Label] = field(default_factory=list)
+    milestone_id: str | None = None
+
+
+@dataclass
+class PullRequest:
+    """Unified pull request / merge request representation."""
+
+    id: str  # Unified ID: {provider}:pr:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    source_branch: str
+    target_branch: str
+    state: PRState
+    url: str
+    created_at: datetime
+    body: str | None = None
+    labels: list[Label] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)  # Issue IDs
+    merged_at: datetime | None = None
+
+
+@dataclass
+class Milestone:
+    """Unified milestone / iteration / sprint representation."""
+
+    id: str  # Unified ID: {provider}:ms:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    state: MilestoneState
+    description: str | None = None
+    due_date: datetime | None = None
+    issue_count: int = 0
+    closed_issue_count: int = 0
+
+
+# =============================================================================
+# Request Models
+# =============================================================================
+
+
+@dataclass
+class IssueCreateRequest:
+    """Request to create a new issue."""
+
+    title: str
+    body: str | None = None
+    type: IssueType = IssueType.TASK
+    labels: list[str] = field(default_factory=list)
+    milestone_id: str | None = None
+
+
+@dataclass
+class IssueUpdateRequest:
+    """Request to update an existing issue."""
+
+    title: str | None = None
+    body: str | None = None
+    state: IssueState | None = None
+    labels: list[str] | None = None
+    milestone_id: str | None = None
+
+
+@dataclass
+class IssueFilters:
+    """Filters for querying issues."""
+
+    state: IssueState | None = None
+    labels: list[str] | None = None
+    milestone_id: str | None = None
+    type: IssueType | None = None
+    limit: int = 100
+
+
+@dataclass
+class PRCreateRequest:
+    """Request to create a new pull request."""
+
+    title: str
+    source_branch: str
+    target_branch: str = "main"
+    body: str | None = None
+    labels: list[str] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PRFilters:
+    """Filters for querying pull requests."""
+
+    state: PRState | None = None
+    source_branch: str | None = None
+    target_branch: str | None = None
+    limit: int = 100
+
+
+@dataclass
+class MilestoneCreateRequest:
+    """Request to create a new milestone."""
+
+    title: str
+    description: str | None = None
+    due_date: datetime | None = None
+
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class ProviderError(Exception):
+    """Base exception for all provider errors."""
+
+    def __init__(self, message: str, cause: Exception | None = None):
+        super().__init__(message)
+        self.cause = cause
+
+
+class AuthenticationError(ProviderError):
+    """Raised when authentication fails."""
+
+    pass
+
+
+class RateLimitError(ProviderError):
+    """Raised when API rate limit is exceeded."""
+
+    def __init__(
+        self, message: str, retry_after: int | None = None, cause: Exception | None = None
+    ):
+        super().__init__(message, cause)
+        self.retry_after = retry_after  # Seconds until rate limit resets
+
+
+class ResourceNotFoundError(ProviderError):
+    """Raised when a requested resource does not exist."""
+
+    def __init__(self, resource_type: str, resource_id: str, cause: Exception | None = None):
+        super().__init__(f"{resource_type} not found: {resource_id}", cause)
+        self.resource_type = resource_type
+        self.resource_id = resource_id
+
+
+class ValidationError(ProviderError):
+    """Raised when request validation fails."""
+
+    def __init__(self, message: str, field: str | None = None, cause: Exception | None = None):
+        super().__init__(message, cause)
+        self.field = field
+
+
+class NetworkError(ProviderError):
+    """Raised when a network operation fails."""
+
+    pass
+
+
+# =============================================================================
+# Provider Interface
+# =============================================================================
+
+
+@runtime_checkable
+class GitProvider(Protocol):
+    """
+    Abstract interface for git hosting providers.
+
+    All git providers (GitHub, Azure DevOps, GitLab) must implement this interface
+    to be used with the doit CLI.
+
+    Usage:
+        provider = ProviderFactory.create()
+        issue = provider.create_issue(IssueCreateRequest(title="Bug fix"))
+    """
+
+    @property
+    def provider_type(self) -> ProviderType:
+        """Return the provider type identifier."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Return the human-readable provider name."""
+        ...
+
+    @property
+    def is_available(self) -> bool:
+        """
+        Check if the provider is properly configured and available.
+
+        Returns:
+            True if the provider can make API calls, False otherwise.
+        """
+        ...
+
+    # -------------------------------------------------------------------------
+    # Issue Operations
+    # -------------------------------------------------------------------------
+
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        """
+        Create a new issue.
+
+        Args:
+            request: Issue creation parameters.
+
+        Returns:
+            The created Issue with populated ID and URL.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+            ProviderError: For other provider-specific errors.
+        """
+        ...
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """
+        Get an issue by its ID.
+
+        Args:
+            issue_id: The issue ID (provider-specific or unified).
+
+        Returns:
+            The Issue object.
+
+        Raises:
+            ResourceNotFoundError: If the issue does not exist.
+            AuthenticationError: If not authenticated.
+        """
+        ...
+
+    def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
+        """
+        List issues matching the given filters.
+
+        Args:
+            filters: Optional filters to apply.
+
+        Returns:
+            List of matching Issue objects.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+        """
+        ...
+
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        """
+        Update an existing issue.
+
+        Args:
+            issue_id: The issue ID to update.
+            updates: The fields to update.
+
+        Returns:
+            The updated Issue object.
+
+        Raises:
+            ResourceNotFoundError: If the issue does not exist.
+            ValidationError: If update parameters are invalid.
+        """
+        ...
+
+    # -------------------------------------------------------------------------
+    # Pull Request Operations
+    # -------------------------------------------------------------------------
+
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        """
+        Create a new pull request.
+
+        Args:
+            request: Pull request creation parameters.
+
+        Returns:
+            The created PullRequest with populated ID and URL.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+            ResourceNotFoundError: If source/target branch doesn't exist.
+        """
+        ...
+
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        """
+        Get a pull request by its ID.
+
+        Args:
+            pr_id: The pull request ID (provider-specific or unified).
+
+        Returns:
+            The PullRequest object.
+
+        Raises:
+            ResourceNotFoundError: If the PR does not exist.
+        """
+        ...
+
+    def list_pull_requests(self, filters: PRFilters | None = None) -> list[PullRequest]:
+        """
+        List pull requests matching the given filters.
+
+        Args:
+            filters: Optional filters to apply.
+
+        Returns:
+            List of matching PullRequest objects.
+        """
+        ...
+
+    # -------------------------------------------------------------------------
+    # Milestone Operations
+    # -------------------------------------------------------------------------
+
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        """
+        Create a new milestone.
+
+        Args:
+            request: Milestone creation parameters.
+
+        Returns:
+            The created Milestone with populated ID.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+        """
+        ...
+
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        """
+        Get a milestone by its ID.
+
+        Args:
+            milestone_id: The milestone ID (provider-specific or unified).
+
+        Returns:
+            The Milestone object.
+
+        Raises:
+            ResourceNotFoundError: If the milestone does not exist.
+        """
+        ...
+
+    def list_milestones(self, state: MilestoneState | None = None) -> list[Milestone]:
+        """
+        List milestones.
+
+        Args:
+            state: Optional state filter (open/closed).
+
+        Returns:
+            List of Milestone objects.
+        """
+        ...
+
+
+class BaseGitProvider(ABC):
+    """
+    Abstract base class for git providers.
+
+    Provides common functionality and enforces the GitProvider interface.
+    Concrete providers should inherit from this class.
+    """
+
+    @property
+    @abstractmethod
+    def provider_type(self) -> ProviderType:
+        """Return the provider type identifier."""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the human-readable provider name."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if the provider is properly configured and available."""
+        pass
+
+    # Issue Operations
+    @abstractmethod
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        pass
+
+    @abstractmethod
+    def get_issue(self, issue_id: str) -> Issue:
+        pass
+
+    @abstractmethod
+    def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
+        pass
+
+    @abstractmethod
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        pass
+
+    # Pull Request Operations
+    @abstractmethod
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        pass
+
+    @abstractmethod
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        pass
+
+    @abstractmethod
+    def list_pull_requests(self, filters: PRFilters | None = None) -> list[PullRequest]:
+        pass
+
+    # Milestone Operations
+    @abstractmethod
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        pass
+
+    @abstractmethod
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        pass
+
+    @abstractmethod
+    def list_milestones(self, state: MilestoneState | None = None) -> list[Milestone]:
+        pass
+
+    # -------------------------------------------------------------------------
+    # Helper Methods (common to all providers)
+    # -------------------------------------------------------------------------
+
+    def _make_unified_id(self, entity_type: str, provider_id: str) -> str:
+        """
+        Create a unified ID from a provider-specific ID.
+
+        Args:
+            entity_type: Type of entity (e.g., "issue", "pr", "ms")
+            provider_id: The provider-specific ID
+
+        Returns:
+            Unified ID in format: {provider}:{entity_type}:{provider_id}
+        """
+        return f"{self.provider_type.value}:{entity_type}:{provider_id}"
+
+    def _extract_provider_id(self, unified_id: str) -> str:
+        """
+        Extract the provider-specific ID from a unified ID.
+
+        Args:
+            unified_id: A unified ID or provider-specific ID
+
+        Returns:
+            The provider-specific ID
+        """
+        if ":" in unified_id:
+            parts = unified_id.split(":")
+            return parts[-1]
+        return unified_id

--- a/specs/044-git-provider-abstraction/data-model.md
+++ b/specs/044-git-provider-abstraction/data-model.md
@@ -1,0 +1,346 @@
+# Data Model: Git Provider Abstraction Layer
+
+**Feature**: 044-git-provider-abstraction
+**Date**: 2026-01-22
+**Status**: Complete
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    GitProvider ||--o{ Issue : "creates/queries"
+    GitProvider ||--o{ PullRequest : "creates/queries"
+    GitProvider ||--o{ Milestone : "creates/queries"
+    Issue ||--o{ Label : "has"
+    PullRequest ||--o{ Label : "has"
+    PullRequest }o--|| Issue : "closes"
+    Milestone ||--o{ Issue : "contains"
+    ProviderConfig ||--|| GitProvider : "configures"
+
+    GitProvider {
+        string provider_type PK "github|azure_devops|gitlab"
+        string name
+        boolean is_available
+    }
+
+    Issue {
+        string id PK
+        string provider_id "Provider-specific ID"
+        string title
+        string body
+        IssueType type "BUG|TASK|USER_STORY|FEATURE"
+        IssueState state "OPEN|CLOSED"
+        string url
+        datetime created_at
+        datetime updated_at
+    }
+
+    PullRequest {
+        string id PK
+        string provider_id "Provider-specific ID"
+        string title
+        string body
+        string source_branch
+        string target_branch
+        PRState state "OPEN|MERGED|CLOSED"
+        string url
+        datetime created_at
+        datetime merged_at
+    }
+
+    Milestone {
+        string id PK
+        string provider_id "Provider-specific ID"
+        string title
+        string description
+        datetime due_date
+        MilestoneState state "OPEN|CLOSED"
+    }
+
+    Label {
+        string name PK
+        string color
+        string description
+    }
+
+    ProviderConfig {
+        string provider PK "github|azure_devops|gitlab"
+        boolean auto_detected
+        string detection_source
+        json provider_settings "Provider-specific config"
+    }
+```
+
+## Entity Definitions
+
+### GitProvider (Abstract Interface)
+
+The base interface that all git providers must implement.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `provider_type` | `str` | Provider identifier: `github`, `azure_devops`, `gitlab` |
+| `name` | `str` | Human-readable name |
+| `is_available` | `bool` | Whether the provider is properly configured |
+
+**Operations**:
+- `create_issue(request: IssueCreateRequest) -> Issue`
+- `get_issue(id: str) -> Issue`
+- `list_issues(filters: IssueFilters) -> list[Issue]`
+- `update_issue(id: str, updates: IssueUpdateRequest) -> Issue`
+- `create_pull_request(request: PRCreateRequest) -> PullRequest`
+- `get_pull_request(id: str) -> PullRequest`
+- `list_pull_requests(filters: PRFilters) -> list[PullRequest]`
+- `create_milestone(request: MilestoneCreateRequest) -> Milestone`
+- `list_milestones() -> list[Milestone]`
+
+### Issue
+
+A unified representation of issues across providers.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `str` | Yes | Unified identifier (format: `{provider}:{provider_id}`) |
+| `provider_id` | `str` | Yes | Provider-specific identifier |
+| `title` | `str` | Yes | Issue title |
+| `body` | `str` | No | Issue description/body (markdown) |
+| `type` | `IssueType` | Yes | Unified type classification |
+| `state` | `IssueState` | Yes | Current state |
+| `labels` | `list[Label]` | No | Associated labels |
+| `milestone` | `Milestone` | No | Associated milestone |
+| `url` | `str` | Yes | Web URL to view the issue |
+| `created_at` | `datetime` | Yes | Creation timestamp |
+| `updated_at` | `datetime` | Yes | Last update timestamp |
+
+**Provider Mappings**:
+
+| Attribute | GitHub | Azure DevOps | GitLab |
+|-----------|--------|--------------|--------|
+| `id` | `github:{number}` | `ado:{work_item_id}` | `gitlab:{iid}` |
+| `provider_id` | Issue number | Work item ID | Issue IID |
+| `type` | From labels | Work item type | From labels |
+| `state` | `open`/`closed` | State field | `opened`/`closed` |
+
+### IssueType (Enum)
+
+```python
+class IssueType(Enum):
+    BUG = "bug"
+    TASK = "task"
+    USER_STORY = "user_story"
+    FEATURE = "feature"
+    EPIC = "epic"
+```
+
+**Provider Type Mappings**:
+
+| Unified Type | GitHub Labels | Azure DevOps Type | GitLab Labels |
+|--------------|---------------|-------------------|---------------|
+| `BUG` | `bug` | `Bug` | `bug` |
+| `TASK` | `task`, `chore` | `Task` | `task` |
+| `USER_STORY` | `enhancement` | `User Story` | `feature` |
+| `FEATURE` | `feature` | `Feature` | `feature` |
+| `EPIC` | `epic` | `Epic` | `epic` |
+
+### IssueState (Enum)
+
+```python
+class IssueState(Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+```
+
+### PullRequest
+
+A unified representation of pull requests / merge requests.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `str` | Yes | Unified identifier |
+| `provider_id` | `str` | Yes | Provider-specific identifier |
+| `title` | `str` | Yes | PR title |
+| `body` | `str` | No | PR description (markdown) |
+| `source_branch` | `str` | Yes | Source branch name |
+| `target_branch` | `str` | Yes | Target branch name |
+| `state` | `PRState` | Yes | Current state |
+| `labels` | `list[Label]` | No | Associated labels |
+| `closes_issues` | `list[Issue]` | No | Issues that will be closed on merge |
+| `url` | `str` | Yes | Web URL to view the PR |
+| `created_at` | `datetime` | Yes | Creation timestamp |
+| `merged_at` | `datetime` | No | Merge timestamp (if merged) |
+
+**Provider Mappings**:
+
+| Attribute | GitHub | Azure DevOps | GitLab |
+|-----------|--------|--------------|--------|
+| `id` | `github:pr:{number}` | `ado:pr:{id}` | `gitlab:mr:{iid}` |
+| `source_branch` | `head.ref` | `sourceRefName` | `source_branch` |
+| `target_branch` | `base.ref` | `targetRefName` | `target_branch` |
+
+### PRState (Enum)
+
+```python
+class PRState(Enum):
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"  # Closed without merging
+```
+
+### Milestone
+
+A unified representation of milestones / iterations / sprints.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `str` | Yes | Unified identifier |
+| `provider_id` | `str` | Yes | Provider-specific identifier |
+| `title` | `str` | Yes | Milestone title |
+| `description` | `str` | No | Milestone description |
+| `due_date` | `datetime` | No | Target completion date |
+| `state` | `MilestoneState` | Yes | Current state |
+| `issue_count` | `int` | No | Number of associated issues |
+| `closed_issue_count` | `int` | No | Number of closed issues |
+
+**Provider Mappings**:
+
+| Attribute | GitHub | Azure DevOps | GitLab |
+|-----------|--------|--------------|--------|
+| Concept | Milestone | Iteration/Sprint | Milestone |
+| `id` | `github:ms:{number}` | `ado:iter:{id}` | `gitlab:ms:{id}` |
+| `due_date` | `due_on` | `finishDate` | `due_date` |
+
+### MilestoneState (Enum)
+
+```python
+class MilestoneState(Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+```
+
+### Label
+
+A unified representation of labels / tags.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `str` | Yes | Label name |
+| `color` | `str` | No | Hex color code (e.g., `#ff0000`) |
+| `description` | `str` | No | Label description |
+
+### ProviderConfig
+
+Configuration for a git provider.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `provider` | `str` | Yes | Provider type |
+| `auto_detected` | `bool` | Yes | Whether config was auto-detected |
+| `detection_source` | `str` | No | How provider was detected |
+| `github` | `GitHubConfig` | No | GitHub-specific settings |
+| `azure_devops` | `AzureDevOpsConfig` | No | Azure DevOps settings |
+| `gitlab` | `GitLabConfig` | No | GitLab-specific settings |
+
+### GitHubConfig
+
+```python
+@dataclass
+class GitHubConfig:
+    auth_method: str = "gh_cli"  # or "token"
+    enterprise_host: str | None = None
+```
+
+### AzureDevOpsConfig
+
+```python
+@dataclass
+class AzureDevOpsConfig:
+    organization: str
+    project: str
+    auth_method: str = "pat"  # Personal Access Token
+    api_version: str = "7.0"
+```
+
+### GitLabConfig
+
+```python
+@dataclass
+class GitLabConfig:
+    host: str = "gitlab.com"
+    auth_method: str = "token"
+```
+
+## Request/Response Models
+
+### IssueCreateRequest
+
+```python
+@dataclass
+class IssueCreateRequest:
+    title: str
+    body: str | None = None
+    type: IssueType = IssueType.TASK
+    labels: list[str] = field(default_factory=list)
+    milestone_id: str | None = None
+```
+
+### IssueUpdateRequest
+
+```python
+@dataclass
+class IssueUpdateRequest:
+    title: str | None = None
+    body: str | None = None
+    state: IssueState | None = None
+    labels: list[str] | None = None
+    milestone_id: str | None = None
+```
+
+### IssueFilters
+
+```python
+@dataclass
+class IssueFilters:
+    state: IssueState | None = None
+    labels: list[str] | None = None
+    milestone_id: str | None = None
+    type: IssueType | None = None
+```
+
+### PRCreateRequest
+
+```python
+@dataclass
+class PRCreateRequest:
+    title: str
+    body: str | None = None
+    source_branch: str
+    target_branch: str = "main"
+    labels: list[str] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)  # Issue IDs
+```
+
+### MilestoneCreateRequest
+
+```python
+@dataclass
+class MilestoneCreateRequest:
+    title: str
+    description: str | None = None
+    due_date: datetime | None = None
+```
+
+## Validation Rules
+
+### Issue
+- `title` must be non-empty and <= 256 characters
+- `body` must be <= 65536 characters (GitHub limit)
+- `type` must be a valid `IssueType`
+
+### PullRequest
+- `title` must be non-empty and <= 256 characters
+- `source_branch` and `target_branch` must be valid branch names
+- `source_branch` must differ from `target_branch`
+
+### Milestone
+- `title` must be non-empty and <= 256 characters
+- `due_date` should be in the future (warning if past)

--- a/specs/044-git-provider-abstraction/plan.md
+++ b/specs/044-git-provider-abstraction/plan.md
@@ -1,0 +1,194 @@
+# Implementation Plan: Git Provider Abstraction Layer
+
+**Branch**: `044-git-provider-abstraction` | **Date**: 2026-01-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/044-git-provider-abstraction/spec.md`
+
+## Summary
+
+Create a unified abstraction layer that enables the doit CLI to work with multiple git hosting providers (GitHub, Azure DevOps, GitLab) through a single consistent interface. The abstraction follows a Strategy pattern where each provider implements a common interface, allowing the CLI commands to remain provider-agnostic while supporting provider-specific behaviors through configuration.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: Typer (CLI), Rich (output), httpx (HTTP client), pytest (testing)
+**Storage**: File-based (`.doit/config/provider.yaml` for provider settings)
+**Testing**: pytest with unit and integration tests
+**Target Platform**: Cross-platform CLI (Linux, macOS, Windows)
+**Project Type**: single (CLI application)
+**Performance Goals**: Provider API calls complete within 5 seconds under normal conditions
+**Constraints**: Must maintain backward compatibility with existing GitHub-based commands
+**Scale/Scope**: 3 providers (GitHub, Azure DevOps, GitLab stub), 6 core operations per provider
+
+## Architecture Overview
+
+<!-- BEGIN:AUTO-GENERATED section="architecture" -->
+```mermaid
+flowchart TD
+    subgraph "CLI Layer"
+        CMD[CLI Commands<br/>roadmapit, specit, checkin]
+    end
+    subgraph "Abstraction Layer"
+        PROV[ProviderFactory]
+        IFACE[GitProvider Interface]
+    end
+    subgraph "Provider Implementations"
+        GH[GitHubProvider]
+        ADO[AzureDevOpsProvider]
+        GL[GitLabProvider]
+    end
+    subgraph "External APIs"
+        GHAPI[GitHub API<br/>via gh CLI]
+        ADOAPI[Azure DevOps API<br/>via REST]
+        GLAPI[GitLab API<br/>via REST]
+    end
+    subgraph "Configuration"
+        CFG[provider.yaml]
+    end
+
+    CMD --> PROV
+    PROV --> IFACE
+    IFACE --> GH
+    IFACE --> ADO
+    IFACE --> GL
+    GH --> GHAPI
+    ADO --> ADOAPI
+    GL --> GLAPI
+    PROV --> CFG
+```
+<!-- END:AUTO-GENERATED -->
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Specification-First | ✅ Pass | Spec completed before planning |
+| II. Persistent Memory | ✅ Pass | Provider config stored in `.doit/config/` |
+| III. Auto-Generated Diagrams | ✅ Pass | Plan includes Mermaid diagrams |
+| IV. Opinionated Workflow | ✅ Pass | Follows specit → planit → taskit flow |
+| V. AI-Native Design | ✅ Pass | Commands remain slash-command compatible |
+
+**Tech Stack Alignment**:
+
+| Requirement | Constitution | This Feature | Status |
+|-------------|--------------|--------------|--------|
+| Language | Python 3.11+ | Python 3.11+ | ✅ Aligned |
+| CLI Framework | Typer | Typer | ✅ Aligned |
+| HTTP Client | httpx | httpx | ✅ Aligned |
+| Testing | pytest | pytest | ✅ Aligned |
+| Storage | File-based markdown | File-based YAML | ✅ Aligned |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/044-git-provider-abstraction/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output - design decisions
+├── data-model.md        # Phase 1 output - entity definitions
+├── quickstart.md        # Phase 1 output - implementation guide
+├── contracts/           # Phase 1 output - interface definitions
+│   └── provider_interface.py
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /doit.taskit)
+```
+
+### Source Code (repository root)
+
+```text
+src/doit_cli/
+├── models/
+│   ├── provider_models.py      # NEW: Provider-agnostic data models
+│   ├── github_epic.py          # EXISTING: Keep for backward compat
+│   └── github_feature.py       # EXISTING: Keep for backward compat
+├── services/
+│   ├── providers/              # NEW: Provider implementations
+│   │   ├── __init__.py
+│   │   ├── base.py             # GitProvider abstract base class
+│   │   ├── github.py           # GitHub implementation (refactored)
+│   │   ├── azure_devops.py     # Azure DevOps implementation
+│   │   └── gitlab.py           # GitLab stub implementation
+│   ├── provider_factory.py     # NEW: Factory for provider instances
+│   ├── provider_config.py      # NEW: Configuration management
+│   └── github_service.py       # REFACTOR: Delegate to providers/github.py
+├── cli/
+│   └── provider.py             # NEW: doit provider commands
+└── utils/
+    ├── github_auth.py          # EXISTING: Keep for GitHub
+    └── provider_auth.py        # NEW: Provider-agnostic auth utilities
+
+tests/
+├── unit/
+│   ├── test_provider_factory.py
+│   ├── test_provider_config.py
+│   └── providers/
+│       ├── test_github_provider.py
+│       ├── test_azure_devops_provider.py
+│       └── test_gitlab_provider.py
+└── integration/
+    └── test_provider_integration.py
+```
+
+**Structure Decision**: Single project structure (CLI application). New code added under `services/providers/` with a factory pattern. Existing `github_service.py` will be refactored to delegate to the new provider abstraction while maintaining backward compatibility.
+
+## Implementation Phases
+
+### Phase 1: Foundation (P1 - Configure Git Provider)
+
+1. Define `GitProvider` abstract base class with core operations
+2. Create `ProviderConfig` for configuration management
+3. Create `ProviderFactory` for instantiating providers
+4. Add `doit provider configure` CLI command
+5. Auto-detect provider from git remote URL
+
+### Phase 2: GitHub Migration (P1 - Create Issues)
+
+1. Create `GitHubProvider` by extracting from `GitHubService`
+2. Implement unified `Issue`, `PullRequest`, `Milestone` models
+3. Update existing commands to use provider abstraction
+4. Maintain backward compatibility (existing tests must pass)
+
+### Phase 3: Azure DevOps (P2)
+
+1. Implement `AzureDevOpsProvider` with REST API
+2. Handle Azure DevOps-specific concepts (work items, iterations)
+3. Implement label/tag translation
+4. Add Azure DevOps authentication (PAT-based)
+
+### Phase 4: GitLab Stub (P3)
+
+1. Create `GitLabProvider` stub with NotImplemented warnings
+2. Document GitLab API requirements for future implementation
+3. Graceful degradation when GitLab operations attempted
+
+### Phase 5: Polish
+
+1. Error handling and rate limiting
+2. Offline mode support
+3. Documentation and examples
+4. Integration tests across providers
+
+## Complexity Tracking
+
+No constitution violations requiring justification. Feature uses approved tech stack and follows established patterns.
+
+## Dependencies
+
+| Dependency | Type | Notes |
+|------------|------|-------|
+| httpx | Existing | Already in constitution |
+| PyYAML | Existing | For provider.yaml config |
+| gh CLI | External | Required for GitHub provider |
+| Azure CLI | External | Optional, can use PAT instead |
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Azure DevOps API differences | Medium | Label translation layer, comprehensive mapping tests |
+| Breaking existing GitHub workflows | High | Maintain GitHubService facade, full regression testing |
+| Authentication complexity | Medium | Clear documentation, interactive wizard |

--- a/specs/044-git-provider-abstraction/quickstart.md
+++ b/specs/044-git-provider-abstraction/quickstart.md
@@ -1,0 +1,658 @@
+# Quickstart: Git Provider Abstraction Implementation
+
+**Feature**: 044-git-provider-abstraction
+**Date**: 2026-01-22
+
+This guide provides step-by-step instructions for implementing the git provider abstraction layer.
+
+## Prerequisites
+
+- Python 3.11+
+- Existing `github_service.py` implementation
+- Understanding of the Strategy pattern
+
+## Implementation Order
+
+Follow this order for a clean implementation:
+
+1. **Provider Models** - Create shared data models
+2. **Provider Interface** - Define the abstract base class
+3. **Provider Factory** - Create the factory for instantiation
+4. **Provider Config** - Handle configuration management
+5. **GitHub Provider** - Extract from existing service
+6. **Azure DevOps Provider** - New implementation
+7. **GitLab Provider** - Stub implementation
+8. **CLI Commands** - Add provider management commands
+9. **Integration** - Update existing commands
+
+## Step 1: Create Provider Models
+
+Create `src/doit_cli/models/provider_models.py`:
+
+```python
+"""Provider-agnostic data models for git operations."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class IssueType(Enum):
+    BUG = "bug"
+    TASK = "task"
+    USER_STORY = "user_story"
+    FEATURE = "feature"
+    EPIC = "epic"
+
+
+class IssueState(Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class PRState(Enum):
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"
+
+
+class MilestoneState(Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass
+class Label:
+    name: str
+    color: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class Issue:
+    id: str
+    provider_id: str
+    title: str
+    state: IssueState
+    url: str
+    created_at: datetime
+    updated_at: datetime
+    body: str | None = None
+    type: IssueType = IssueType.TASK
+    labels: list[Label] = field(default_factory=list)
+    milestone_id: str | None = None
+
+
+@dataclass
+class PullRequest:
+    id: str
+    provider_id: str
+    title: str
+    source_branch: str
+    target_branch: str
+    state: PRState
+    url: str
+    created_at: datetime
+    body: str | None = None
+    labels: list[Label] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)
+    merged_at: datetime | None = None
+
+
+@dataclass
+class Milestone:
+    id: str
+    provider_id: str
+    title: str
+    state: MilestoneState
+    description: str | None = None
+    due_date: datetime | None = None
+    issue_count: int = 0
+    closed_issue_count: int = 0
+```
+
+## Step 2: Create Provider Base Class
+
+Create `src/doit_cli/services/providers/base.py`:
+
+```python
+"""Abstract base class for git providers."""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from doit_cli.models.provider_models import (
+        Issue,
+        IssueFilters,
+        IssueCreateRequest,
+        IssueUpdateRequest,
+        Milestone,
+        MilestoneCreateRequest,
+        MilestoneState,
+        PullRequest,
+        PRCreateRequest,
+        PRFilters,
+    )
+
+
+class ProviderType(Enum):
+    GITHUB = "github"
+    AZURE_DEVOPS = "azure_devops"
+    GITLAB = "gitlab"
+
+
+class GitProvider(ABC):
+    """Abstract interface for git hosting providers."""
+
+    @property
+    @abstractmethod
+    def provider_type(self) -> ProviderType:
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def is_available(self) -> bool:
+        pass
+
+    # Issue operations
+    @abstractmethod
+    def create_issue(self, request: "IssueCreateRequest") -> "Issue":
+        pass
+
+    @abstractmethod
+    def get_issue(self, issue_id: str) -> "Issue":
+        pass
+
+    @abstractmethod
+    def list_issues(self, filters: "IssueFilters | None" = None) -> list["Issue"]:
+        pass
+
+    @abstractmethod
+    def update_issue(self, issue_id: str, updates: "IssueUpdateRequest") -> "Issue":
+        pass
+
+    # PR operations
+    @abstractmethod
+    def create_pull_request(self, request: "PRCreateRequest") -> "PullRequest":
+        pass
+
+    @abstractmethod
+    def get_pull_request(self, pr_id: str) -> "PullRequest":
+        pass
+
+    @abstractmethod
+    def list_pull_requests(self, filters: "PRFilters | None" = None) -> list["PullRequest"]:
+        pass
+
+    # Milestone operations
+    @abstractmethod
+    def create_milestone(self, request: "MilestoneCreateRequest") -> "Milestone":
+        pass
+
+    @abstractmethod
+    def get_milestone(self, milestone_id: str) -> "Milestone":
+        pass
+
+    @abstractmethod
+    def list_milestones(self, state: "MilestoneState | None" = None) -> list["Milestone"]:
+        pass
+```
+
+## Step 3: Create Provider Factory
+
+Create `src/doit_cli/services/provider_factory.py`:
+
+```python
+"""Factory for creating git provider instances."""
+
+import subprocess
+from pathlib import Path
+
+from doit_cli.services.providers.base import GitProvider, ProviderType
+from doit_cli.services.provider_config import ProviderConfig
+
+
+class ProviderFactory:
+    """Factory for creating the appropriate git provider."""
+
+    @classmethod
+    def create(cls, config: ProviderConfig | None = None) -> GitProvider:
+        """Create a provider instance based on configuration."""
+        if config is None:
+            config = ProviderConfig.load()
+
+        provider_type = config.provider or cls._detect_provider()
+
+        if provider_type == ProviderType.GITHUB:
+            from doit_cli.services.providers.github import GitHubProvider
+            return GitHubProvider()
+        elif provider_type == ProviderType.AZURE_DEVOPS:
+            from doit_cli.services.providers.azure_devops import AzureDevOpsProvider
+            return AzureDevOpsProvider(config.azure_devops)
+        elif provider_type == ProviderType.GITLAB:
+            from doit_cli.services.providers.gitlab import GitLabProvider
+            return GitLabProvider()
+        else:
+            raise ValueError(f"Unknown provider: {provider_type}")
+
+    @classmethod
+    def _detect_provider(cls) -> ProviderType:
+        """Auto-detect provider from git remote URL."""
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            remote_url = result.stdout.strip()
+
+            if "github.com" in remote_url or "ghe." in remote_url:
+                return ProviderType.GITHUB
+            elif "dev.azure.com" in remote_url or "visualstudio.com" in remote_url:
+                return ProviderType.AZURE_DEVOPS
+            elif "gitlab" in remote_url:
+                return ProviderType.GITLAB
+
+        except subprocess.CalledProcessError:
+            pass
+
+        # Default to GitHub
+        return ProviderType.GITHUB
+```
+
+## Step 4: Create Provider Config
+
+Create `src/doit_cli/services/provider_config.py`:
+
+```python
+"""Provider configuration management."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from doit_cli.services.providers.base import ProviderType
+
+
+@dataclass
+class AzureDevOpsConfig:
+    organization: str = ""
+    project: str = ""
+    auth_method: str = "pat"
+    api_version: str = "7.0"
+
+
+@dataclass
+class ProviderConfig:
+    provider: ProviderType | None = None
+    auto_detected: bool = False
+    detection_source: str | None = None
+    azure_devops: AzureDevOpsConfig = field(default_factory=AzureDevOpsConfig)
+
+    CONFIG_PATH = Path(".doit/config/provider.yaml")
+
+    @classmethod
+    def load(cls) -> "ProviderConfig":
+        """Load configuration from file."""
+        if not cls.CONFIG_PATH.exists():
+            return cls()
+
+        with open(cls.CONFIG_PATH) as f:
+            data = yaml.safe_load(f) or {}
+
+        config = cls()
+        if "provider" in data:
+            config.provider = ProviderType(data["provider"])
+        config.auto_detected = data.get("auto_detected", False)
+        config.detection_source = data.get("detection_source")
+
+        if "azure_devops" in data:
+            ado = data["azure_devops"]
+            config.azure_devops = AzureDevOpsConfig(
+                organization=ado.get("organization", ""),
+                project=ado.get("project", ""),
+                auth_method=ado.get("auth_method", "pat"),
+            )
+
+        return config
+
+    def save(self) -> None:
+        """Save configuration to file."""
+        self.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+        data: dict[str, Any] = {}
+        if self.provider:
+            data["provider"] = self.provider.value
+        data["auto_detected"] = self.auto_detected
+        if self.detection_source:
+            data["detection_source"] = self.detection_source
+
+        if self.provider == ProviderType.AZURE_DEVOPS:
+            data["azure_devops"] = {
+                "organization": self.azure_devops.organization,
+                "project": self.azure_devops.project,
+                "auth_method": self.azure_devops.auth_method,
+            }
+
+        with open(self.CONFIG_PATH, "w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+```
+
+## Step 5: Implement GitHub Provider
+
+Create `src/doit_cli/services/providers/github.py`:
+
+```python
+"""GitHub provider implementation using gh CLI."""
+
+import json
+import subprocess
+from datetime import datetime
+
+from doit_cli.models.provider_models import (
+    Issue,
+    IssueCreateRequest,
+    IssueFilters,
+    IssueState,
+    IssueType,
+    IssueUpdateRequest,
+    Label,
+    Milestone,
+    MilestoneCreateRequest,
+    MilestoneState,
+    PullRequest,
+    PRCreateRequest,
+    PRFilters,
+    PRState,
+)
+from doit_cli.services.providers.base import GitProvider, ProviderType
+
+
+class GitHubProvider(GitProvider):
+    """GitHub implementation using the gh CLI."""
+
+    @property
+    def provider_type(self) -> ProviderType:
+        return ProviderType.GITHUB
+
+    @property
+    def name(self) -> str:
+        return "GitHub"
+
+    @property
+    def is_available(self) -> bool:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+            )
+            return result.returncode == 0
+        except FileNotFoundError:
+            return False
+
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        cmd = ["gh", "issue", "create", "--title", request.title]
+        if request.body:
+            cmd.extend(["--body", request.body])
+        for label in request.labels:
+            cmd.extend(["--label", label])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # Parse created issue URL and fetch details
+        url = result.stdout.strip()
+        issue_number = url.split("/")[-1]
+        return self.get_issue(issue_number)
+
+    def get_issue(self, issue_id: str) -> Issue:
+        result = subprocess.run(
+            ["gh", "issue", "view", issue_id, "--json",
+             "number,title,body,state,url,createdAt,updatedAt,labels"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(result.stdout)
+        return self._parse_issue(data)
+
+    def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
+        cmd = ["gh", "issue", "list", "--json",
+               "number,title,body,state,url,createdAt,updatedAt,labels"]
+
+        if filters:
+            if filters.state:
+                cmd.extend(["--state", filters.state.value])
+            if filters.labels:
+                for label in filters.labels:
+                    cmd.extend(["--label", label])
+            if filters.limit:
+                cmd.extend(["--limit", str(filters.limit)])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        issues_data = json.loads(result.stdout)
+        return [self._parse_issue(d) for d in issues_data]
+
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        cmd = ["gh", "issue", "edit", issue_id]
+        if updates.title:
+            cmd.extend(["--title", updates.title])
+        if updates.body:
+            cmd.extend(["--body", updates.body])
+        if updates.labels is not None:
+            for label in updates.labels:
+                cmd.extend(["--add-label", label])
+
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+        if updates.state == IssueState.CLOSED:
+            subprocess.run(
+                ["gh", "issue", "close", issue_id],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        return self.get_issue(issue_id)
+
+    # PR and Milestone methods follow similar patterns...
+    # (Implementation continues for all interface methods)
+
+    def _parse_issue(self, data: dict) -> Issue:
+        """Parse gh CLI JSON output into Issue model."""
+        return Issue(
+            id=f"github:{data['number']}",
+            provider_id=str(data["number"]),
+            title=data["title"],
+            body=data.get("body"),
+            state=IssueState.OPEN if data["state"] == "OPEN" else IssueState.CLOSED,
+            url=data["url"],
+            created_at=datetime.fromisoformat(data["createdAt"].replace("Z", "+00:00")),
+            updated_at=datetime.fromisoformat(data["updatedAt"].replace("Z", "+00:00")),
+            labels=[Label(name=l["name"]) for l in data.get("labels", [])],
+        )
+```
+
+## Step 6: Update Existing Service
+
+Refactor `src/doit_cli/services/github_service.py` to delegate:
+
+```python
+"""GitHub service - backward compatibility layer."""
+
+from doit_cli.services.provider_factory import ProviderFactory
+from doit_cli.services.providers.base import ProviderType
+
+
+class GitHubService:
+    """
+    Backward-compatible facade for GitHub operations.
+
+    Delegates to GitHubProvider while maintaining existing interface.
+    """
+
+    def __init__(self):
+        self._provider = ProviderFactory.create()
+        if self._provider.provider_type != ProviderType.GITHUB:
+            raise ValueError("GitHubService requires GitHub provider")
+
+    def create_issue(self, title: str, body: str, labels: list[str] | None = None):
+        """Create a GitHub issue (legacy interface)."""
+        from doit_cli.models.provider_models import IssueCreateRequest
+
+        request = IssueCreateRequest(
+            title=title,
+            body=body,
+            labels=labels or [],
+        )
+        issue = self._provider.create_issue(request)
+        return {"number": issue.provider_id, "url": issue.url}
+
+    # ... other methods maintain backward compatibility
+```
+
+## Step 7: Add CLI Commands
+
+Create `src/doit_cli/cli/provider.py`:
+
+```python
+"""CLI commands for provider management."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from doit_cli.services.provider_factory import ProviderFactory
+from doit_cli.services.provider_config import ProviderConfig
+from doit_cli.services.providers.base import ProviderType
+
+app = typer.Typer(help="Git provider management commands")
+console = Console()
+
+
+@app.command()
+def configure(
+    provider: str = typer.Option(None, help="Provider: github, azure_devops, gitlab"),
+):
+    """Configure the git provider for this project."""
+    config = ProviderConfig()
+
+    if provider:
+        config.provider = ProviderType(provider)
+        config.auto_detected = False
+    else:
+        # Auto-detect
+        config.provider = ProviderFactory._detect_provider()
+        config.auto_detected = True
+        config.detection_source = "git_remote"
+
+    config.save()
+    console.print(f"[green]Provider configured: {config.provider.value}[/green]")
+
+
+@app.command()
+def status():
+    """Show current provider status."""
+    config = ProviderConfig.load()
+    provider = ProviderFactory.create(config)
+
+    table = Table(title="Provider Status")
+    table.add_column("Property", style="cyan")
+    table.add_column("Value")
+
+    table.add_row("Provider", provider.name)
+    table.add_row("Type", provider.provider_type.value)
+    table.add_row("Available", "✓" if provider.is_available else "✗")
+    table.add_row("Auto-detected", "Yes" if config.auto_detected else "No")
+
+    console.print(table)
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+```python
+# tests/unit/test_provider_factory.py
+import pytest
+from unittest.mock import patch
+
+from doit_cli.services.provider_factory import ProviderFactory
+from doit_cli.services.providers.base import ProviderType
+
+
+class TestProviderDetection:
+    @patch("subprocess.run")
+    def test_detect_github(self, mock_run):
+        mock_run.return_value.stdout = "https://github.com/user/repo.git"
+        mock_run.return_value.returncode = 0
+
+        detected = ProviderFactory._detect_provider()
+
+        assert detected == ProviderType.GITHUB
+
+    @patch("subprocess.run")
+    def test_detect_azure_devops(self, mock_run):
+        mock_run.return_value.stdout = "https://dev.azure.com/org/project/_git/repo"
+        mock_run.return_value.returncode = 0
+
+        detected = ProviderFactory._detect_provider()
+
+        assert detected == ProviderType.AZURE_DEVOPS
+```
+
+### Integration Tests
+
+```python
+# tests/integration/test_provider_integration.py
+import pytest
+from doit_cli.services.provider_factory import ProviderFactory
+
+
+@pytest.mark.integration
+class TestProviderIntegration:
+    def test_github_provider_availability(self):
+        """Test that GitHub provider can check availability."""
+        provider = ProviderFactory.create()
+        # Should not raise
+        _ = provider.is_available
+
+    def test_create_and_close_issue(self):
+        """End-to-end test for issue lifecycle."""
+        provider = ProviderFactory.create()
+        if not provider.is_available:
+            pytest.skip("Provider not available")
+
+        # Create
+        from doit_cli.models.provider_models import IssueCreateRequest
+        issue = provider.create_issue(
+            IssueCreateRequest(title="Test issue", body="Test body")
+        )
+        assert issue.id is not None
+
+        # Close
+        from doit_cli.models.provider_models import IssueState, IssueUpdateRequest
+        updated = provider.update_issue(
+            issue.provider_id,
+            IssueUpdateRequest(state=IssueState.CLOSED)
+        )
+        assert updated.state == IssueState.CLOSED
+```
+
+## Next Steps
+
+After implementation:
+
+1. Run `/doit.taskit` to generate implementation tasks
+2. Implement each task following TDD (write tests first)
+3. Run `/doit.reviewit` for code review
+4. Run `/doit.checkin` to complete the feature

--- a/specs/044-git-provider-abstraction/research.md
+++ b/specs/044-git-provider-abstraction/research.md
@@ -1,0 +1,230 @@
+# Research: Git Provider Abstraction Layer
+
+**Feature**: 044-git-provider-abstraction
+**Date**: 2026-01-22
+**Status**: Complete
+
+## Design Decisions
+
+### DD-001: Strategy Pattern for Provider Abstraction
+
+**Decision**: Use the Strategy pattern where each git provider implements a common `GitProvider` interface.
+
+**Rationale**:
+- Enables runtime provider selection based on configuration
+- Each provider can have custom implementation details while exposing a uniform API
+- New providers can be added without modifying existing code
+- Aligns with Python's Protocol/ABC patterns
+
+**Alternatives Considered**:
+1. **Adapter Pattern**: Wrap each provider's API in an adapter. Rejected because we need a clean abstraction, not compatibility with existing interfaces.
+2. **Plugin Architecture**: Dynamic loading of provider modules. Rejected as over-engineering for 3 known providers.
+
+### DD-002: Provider Detection via Git Remote URL
+
+**Decision**: Auto-detect the git provider by parsing the remote URL pattern.
+
+**Detection Patterns**:
+| Provider | URL Patterns |
+|----------|-------------|
+| GitHub | `github.com`, `ghe.*/` (enterprise) |
+| Azure DevOps | `dev.azure.com`, `*.visualstudio.com` |
+| GitLab | `gitlab.com`, `gitlab.*/` (self-hosted) |
+
+**Rationale**:
+- Zero-configuration for most users
+- Git remote is already configured in projects
+- Fallback to explicit configuration when detection fails
+
+### DD-003: Configuration Storage in YAML
+
+**Decision**: Store provider configuration in `.doit/config/provider.yaml`.
+
+**Structure**:
+```yaml
+provider: github  # or azure_devops, gitlab
+auto_detected: true
+detection_source: git_remote
+
+github:
+  auth_method: gh_cli  # or token
+
+azure_devops:
+  organization: myorg
+  project: myproject
+  auth_method: pat  # personal access token
+
+gitlab:
+  host: gitlab.com  # or self-hosted URL
+  auth_method: token
+```
+
+**Rationale**:
+- YAML is human-readable and editable
+- Consistent with other doit configuration files
+- Supports provider-specific settings without schema changes
+
+### DD-004: GitHub Provider via gh CLI
+
+**Decision**: Use the `gh` CLI for GitHub operations rather than direct REST API calls.
+
+**Rationale**:
+- `gh` handles authentication automatically
+- Existing `github_service.py` already uses this approach
+- Reduces authentication complexity for users
+- Enterprise GitHub support comes for free
+
+**Trade-offs**:
+- Requires `gh` CLI to be installed
+- Less control over API calls
+- Error messages may be less precise
+
+### DD-005: Azure DevOps Provider via REST API
+
+**Decision**: Use Azure DevOps REST API directly with httpx.
+
+**Rationale**:
+- Azure CLI (`az`) is heavyweight and complex
+- REST API is well-documented and stable
+- PAT authentication is straightforward
+- Enables fine-grained control over requests
+
+**API Endpoints**:
+```text
+Work Items:  https://dev.azure.com/{org}/{project}/_apis/wit/workitems
+Pull Requests: https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/pullrequests
+Iterations: https://dev.azure.com/{org}/{project}/_apis/work/teamsettings/iterations
+```
+
+### DD-006: Unified Data Models
+
+**Decision**: Create provider-agnostic data models that abstract provider-specific concepts.
+
+**Mappings**:
+| Unified Model | GitHub | Azure DevOps | GitLab |
+|--------------|--------|--------------|--------|
+| Issue | Issue | Work Item (Bug/Task/User Story) | Issue |
+| PullRequest | Pull Request | Pull Request | Merge Request |
+| Milestone | Milestone | Iteration/Sprint | Milestone |
+| Label | Label | Tag | Label |
+
+**Rationale**:
+- CLI commands work identically regardless of provider
+- Provider-specific details are encapsulated in provider implementations
+- Users don't need to learn provider-specific terminology
+
+### DD-007: Label/Tag Translation
+
+**Decision**: Implement a translation layer for labels between providers.
+
+**Approach**:
+```python
+class LabelMapper:
+    def to_provider(self, label: str, provider: str) -> str:
+        """Convert unified label to provider-specific format."""
+
+    def from_provider(self, tag: str, provider: str) -> str:
+        """Convert provider-specific tag to unified label."""
+```
+
+**Examples**:
+- GitHub label `bug` → Azure DevOps work item type `Bug`
+- Azure DevOps tag `P1` → unified priority label `priority:high`
+
+### DD-008: Backward Compatibility Strategy
+
+**Decision**: Maintain `GitHubService` as a facade that delegates to `GitHubProvider`.
+
+**Implementation**:
+```python
+# github_service.py (existing interface)
+class GitHubService:
+    def __init__(self):
+        self._provider = GitHubProvider()
+
+    def create_issue(self, title, body, labels):
+        return self._provider.create_issue(
+            IssueCreateRequest(title=title, body=body, labels=labels)
+        )
+```
+
+**Rationale**:
+- Existing code continues to work without modification
+- Gradual migration path for internal callers
+- All existing tests remain valid
+
+### DD-009: Error Handling Strategy
+
+**Decision**: Define provider-agnostic exceptions that wrap provider-specific errors.
+
+**Exception Hierarchy**:
+```text
+ProviderError (base)
+├── AuthenticationError
+├── RateLimitError
+├── ResourceNotFoundError
+├── ValidationError
+└── NetworkError
+```
+
+**Rationale**:
+- Callers handle errors uniformly
+- Provider-specific details available via `.cause` attribute
+- Enables consistent error messages across providers
+
+### DD-010: GitLab as Stub Implementation
+
+**Decision**: Implement GitLab provider as a stub that raises `NotImplementedError` with guidance.
+
+**Implementation**:
+```python
+class GitLabProvider(GitProvider):
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        raise NotImplementedError(
+            "GitLab support is not yet implemented. "
+            "See https://github.com/seanbarlow/doit/issues/XXX for status."
+        )
+```
+
+**Rationale**:
+- Establishes the interface for future implementation
+- Clear feedback when GitLab is detected but not supported
+- Allows testing of provider detection and configuration
+
+## Open Questions (Resolved)
+
+### OQ-001: Should we support multiple providers simultaneously?
+
+**Resolution**: No. A project uses one provider at a time. The configuration stores a single active provider.
+
+**Reasoning**: Multi-provider support adds complexity with little benefit. Users typically have one source control system per project.
+
+### OQ-002: How to handle Azure DevOps work item types?
+
+**Resolution**: Map to unified Issue model with a `type` field.
+
+```python
+@dataclass
+class Issue:
+    id: str
+    title: str
+    body: str
+    type: IssueType  # BUG, TASK, USER_STORY, FEATURE
+    labels: list[str]
+```
+
+### OQ-003: Authentication token storage?
+
+**Resolution**: Defer to existing mechanisms:
+- GitHub: `gh auth` manages credentials
+- Azure DevOps: PAT stored in environment variable `AZURE_DEVOPS_PAT`
+- GitLab: Token in environment variable `GITLAB_TOKEN`
+
+No custom credential storage to avoid security concerns.
+
+## References
+
+- [Azure DevOps REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/)
+- [GitHub CLI](https://cli.github.com/manual/)
+- [GitLab API](https://docs.gitlab.com/ee/api/)
+- [Python Protocol (PEP 544)](https://peps.python.org/pep-0544/)

--- a/specs/044-git-provider-abstraction/spec.md
+++ b/specs/044-git-provider-abstraction/spec.md
@@ -1,0 +1,270 @@
+# Feature Specification: Git Provider Abstraction Layer
+
+**Feature Branch**: `[044-git-provider-abstraction]`
+**Created**: 2026-01-22
+**Status**: Complete
+**Input**: User description: "Git provider abstraction layer - Create a unified interface for git providers (GitHub, Azure DevOps, GitLab) to enable easier addition of future providers and consistent behavior across platforms"
+
+## Summary
+
+Create a unified abstraction layer that enables the doit CLI to work with multiple git hosting providers (GitHub, Azure DevOps, GitLab) through a single consistent interface. This eliminates provider-specific code scattered throughout the CLI and enables easy addition of new providers without modifying existing commands.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Git Provider (Priority: P1)
+
+A developer setting up doit for a new project needs to specify which git provider they are using so the CLI knows how to interact with their repository for issues, epics, and pull requests.
+
+**Why this priority**: Without provider configuration, no provider-specific features can work. This is the foundation for all other functionality.
+
+**Independent Test**: Can be fully tested by configuring a provider and verifying the configuration is persisted and loaded correctly on subsequent CLI invocations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project without provider configuration, **When** the user runs `doit init` or `doit provider configure`, **Then** they are prompted to select their git provider (GitHub, Azure DevOps, GitLab, or None)
+2. **Given** a project with a GitHub remote URL, **When** the user runs provider configuration, **Then** GitHub is auto-detected and suggested as the default provider
+3. **Given** a user selects a provider, **When** configuration completes, **Then** the provider choice is saved to `.doit/config/provider.yaml`
+4. **Given** invalid or unsupported provider credentials, **When** configuration is attempted, **Then** a clear error message explains what is missing or incorrect
+
+---
+
+### User Story 2 - Create Issues and Epics (Priority: P1)
+
+A developer using `/doit.specit` or `doit roadmapit add` wants to create issues and epics in their git provider's issue tracker, regardless of which provider they use.
+
+**Why this priority**: Issue creation is one of the most frequent provider interactions. The abstraction must handle this core use case reliably.
+
+**Independent Test**: Can be fully tested by creating an epic and issue through the abstraction layer and verifying they appear correctly in the provider's web interface.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured provider, **When** `doit roadmapit add` creates an epic, **Then** the epic is created in the provider's issue system with correct labels
+2. **Given** a configured provider, **When** `/doit.specit` creates feature issues, **Then** issues are created with appropriate linking (parent/child, epic references)
+3. **Given** different label naming conventions across providers, **When** an issue is created, **Then** labels are translated to the provider's format (e.g., GitHub labels vs Azure DevOps tags)
+4. **Given** no provider configured, **When** issue creation is attempted, **Then** a helpful message explains how to configure a provider
+
+---
+
+### User Story 3 - Query Issues and Status (Priority: P2)
+
+A developer running `doit roadmapit show` or `doit team status` wants to see issue status and synchronization information from their git provider.
+
+**Why this priority**: Reading issue status is important but secondary to creating issues. Projects can function with local-only tracking if needed.
+
+**Independent Test**: Can be fully tested by querying existing issues through the abstraction and verifying the returned data matches what's visible in the provider's web interface.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured provider with existing epics, **When** `doit roadmapit show` runs, **Then** epic status (open/closed) is fetched and displayed
+2. **Given** a repository with multiple issues, **When** issues are queried, **Then** results include consistent fields (number, title, state, labels) regardless of provider
+3. **Given** a provider API rate limit is exceeded, **When** a query is attempted, **Then** the system handles the rate limit gracefully with clear messaging
+
+---
+
+### User Story 4 - Manage Pull Requests / Merge Requests (Priority: P2)
+
+A developer using `/doit.checkin` wants to create pull requests (GitHub, GitLab) or merge requests (Azure DevOps) to submit their completed feature for review.
+
+**Why this priority**: PR/MR creation is the final step of the feature workflow. It's important but occurs less frequently than issue operations.
+
+**Independent Test**: Can be fully tested by creating a PR/MR through the abstraction and verifying it appears correctly in the provider with correct target branch and description.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured provider, **When** `/doit.checkin` creates a PR/MR, **Then** it is created with the correct source branch, target branch, and description
+2. **Given** GitHub, GitLab, or Azure DevOps, **When** a PR/MR is created, **Then** the terminology and URLs in output match the provider (PR for GitHub/GitLab, MR for Azure DevOps)
+3. **Given** a PR/MR is created successfully, **When** the command completes, **Then** the PR/MR URL is displayed for the user to open
+
+---
+
+### User Story 5 - Manage Milestones (Priority: P3)
+
+A developer using `doit roadmapit sync-milestones` wants to synchronize priority-based milestones with their git provider's milestone or iteration system.
+
+**Why this priority**: Milestone management is a convenience feature that enhances project tracking but isn't essential for core workflow.
+
+**Independent Test**: Can be fully tested by syncing milestones and verifying they appear correctly in the provider's project board or milestone list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured provider, **When** `doit roadmapit sync-milestones` runs, **Then** milestones are created or updated in the provider's system
+2. **Given** Azure DevOps uses "iterations" instead of "milestones", **When** milestone sync runs, **Then** the abstraction maps to the correct Azure DevOps concept
+3. **Given** a milestone already exists in the provider, **When** sync runs, **Then** the existing milestone is updated rather than duplicated
+
+---
+
+### Edge Cases
+
+- What happens when the provider API is unreachable (network issues)?
+  - System operates in offline mode with clear indication; commands that require provider access fail gracefully with specific error messages
+- How does the system handle provider authentication expiration?
+  - Clear error message with instructions to re-authenticate; no silent failures
+- What happens when a user switches providers mid-project?
+  - Warning about existing provider data; option to migrate or start fresh
+- How are provider-specific features that don't exist in all providers handled?
+  - Features gracefully degrade; e.g., if a provider doesn't support labels, a warning is shown but the operation continues
+
+## User Journey Visualization
+
+<!-- BEGIN:AUTO-GENERATED section="user-journey" -->
+```mermaid
+flowchart LR
+    subgraph "User Story 1 - Configure Git Provider"
+        US1_S[Run doit init] --> US1_A[Select provider] --> US1_B[Enter credentials] --> US1_E[Configuration saved]
+    end
+    subgraph "User Story 2 - Create Issues and Epics"
+        US2_S[Run roadmapit add] --> US2_A[Abstraction layer processes] --> US2_B[Provider API called] --> US2_E[Issue created in provider]
+    end
+    subgraph "User Story 3 - Query Issues and Status"
+        US3_S[Run roadmapit show] --> US3_A[Fetch from provider] --> US3_B[Normalize response] --> US3_E[Display unified status]
+    end
+    subgraph "User Story 4 - Manage PRs/MRs"
+        US4_S[Run doit.checkin] --> US4_A[Create PR/MR via abstraction] --> US4_E[PR/MR URL displayed]
+    end
+    subgraph "User Story 5 - Manage Milestones"
+        US5_S[Run sync-milestones] --> US5_A[Map priorities to provider milestones] --> US5_E[Milestones synced]
+    end
+```
+<!-- END:AUTO-GENERATED -->
+
+## Entity Relationships
+
+<!-- BEGIN:AUTO-GENERATED section="entity-relationships" -->
+```mermaid
+erDiagram
+    GIT_PROVIDER ||--o{ REPOSITORY : "manages"
+    GIT_PROVIDER ||--o{ ISSUE : "tracks"
+    GIT_PROVIDER ||--o{ PULL_REQUEST : "hosts"
+    GIT_PROVIDER ||--o{ MILESTONE : "organizes"
+    REPOSITORY ||--o{ ISSUE : "contains"
+    REPOSITORY ||--o{ PULL_REQUEST : "contains"
+    REPOSITORY ||--o{ MILESTONE : "contains"
+    ISSUE ||--o{ ISSUE : "links to (parent/child)"
+    MILESTONE ||--o{ ISSUE : "groups"
+
+    GIT_PROVIDER {
+        string type PK "github, azure_devops, gitlab"
+        string base_url
+        string auth_method
+        datetime last_authenticated
+    }
+    REPOSITORY {
+        string id PK
+        string provider_type FK
+        string owner
+        string name
+        string default_branch
+    }
+    ISSUE {
+        string id PK
+        string repository_id FK
+        int number
+        string title
+        string state "open, closed"
+        string issue_type "epic, feature, bug, task"
+        string parent_id FK
+    }
+    PULL_REQUEST {
+        string id PK
+        string repository_id FK
+        int number
+        string title
+        string source_branch
+        string target_branch
+        string state "open, merged, closed"
+    }
+    MILESTONE {
+        string id PK
+        string repository_id FK
+        string title
+        string state "open, closed"
+        date due_date
+    }
+```
+<!-- END:AUTO-GENERATED -->
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Provider Interface
+
+- **FR-001**: System MUST define a unified provider interface with operations: create_issue, get_issue, list_issues, create_pull_request, get_pull_request, create_milestone, list_milestones
+- **FR-002**: System MUST support provider implementations for GitHub, Azure DevOps, and GitLab (GitLab may be stub initially)
+- **FR-003**: System MUST auto-detect the provider type from the git remote URL when possible
+- **FR-004**: System MUST allow explicit provider configuration override regardless of remote URL detection
+
+#### Configuration
+
+- **FR-005**: System MUST store provider configuration in `.doit/config/provider.yaml`
+- **FR-006**: System MUST support authentication via environment variables, credential files, or interactive prompts
+- **FR-007**: System MUST validate provider credentials on configuration and provide clear error messages for failures
+- **FR-008**: System MUST NOT store sensitive credentials in plain text in configuration files (use credential helpers or environment variables)
+
+#### Issue Management
+
+- **FR-009**: System MUST create issues with: title, body, labels, and optional parent issue reference
+- **FR-010**: System MUST query issues with filtering by: state (open/closed), labels, and milestone
+- **FR-011**: System MUST translate label names between providers when necessary (e.g., "epic" label on GitHub vs "Epic" work item type on Azure DevOps)
+- **FR-012**: System MUST support linking issues to parent epics using provider-specific mechanisms
+
+#### Pull Request / Merge Request
+
+- **FR-013**: System MUST create PRs/MRs with: title, body, source branch, target branch
+- **FR-014**: System MUST return the PR/MR URL for user reference
+- **FR-015**: System MUST use provider-appropriate terminology in user-facing messages (PR vs MR)
+
+#### Milestone Management
+
+- **FR-016**: System MUST create and update milestones with: title, description, due date
+- **FR-017**: System MUST map doit priority levels (P1-P4) to milestone titles consistently across providers
+- **FR-018**: System MUST handle provider-specific milestone concepts (GitHub milestones, Azure DevOps iterations, GitLab milestones)
+
+#### Error Handling
+
+- **FR-019**: System MUST handle API rate limits with exponential backoff and clear user messaging
+- **FR-020**: System MUST provide actionable error messages for authentication failures
+- **FR-021**: System MUST operate gracefully when provider is unavailable (offline mode for local-only operations)
+
+### Key Entities
+
+- **GitProvider**: Abstract interface representing a git hosting provider; defines operations for issues, PRs, and milestones
+- **ProviderConfig**: Configuration data for a specific provider including authentication method and base URL
+- **Repository**: Unified representation of a git repository with owner, name, and provider reference
+- **Issue**: Unified representation of an issue/work item with number, title, state, labels, and parent reference
+- **PullRequest**: Unified representation of a PR/MR with number, title, branches, and state
+- **Milestone**: Unified representation of a milestone/iteration with title, state, and due date
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing GitHub-specific doit commands work without modification through the abstraction layer
+- **SC-002**: Adding a new provider implementation requires changes only in the provider layer (no modifications to existing commands)
+- **SC-003**: Issue creation succeeds on configured provider within 5 seconds under normal network conditions
+- **SC-004**: Provider configuration completes in under 2 minutes including authentication
+- **SC-005**: 100% of provider-specific API calls are routed through the abstraction layer (no direct provider calls in commands)
+- **SC-006**: Clear, actionable error messages are shown for all authentication and API failures
+- **SC-007**: Offline operations (local-only commands) work without any provider configuration
+
+## Assumptions
+
+- Users have accounts on their chosen git provider with appropriate permissions
+- Network connectivity is available for provider operations (offline mode handles unavailability gracefully)
+- The `gh` CLI is available for GitHub (existing dependency); Azure DevOps and GitLab may use REST APIs directly
+- Provider APIs are reasonably stable and backwards compatible
+- Users understand basic git concepts (remotes, branches, PRs)
+
+## Out of Scope
+
+- Full GitLab implementation (stub with warning is acceptable for this feature)
+- Migration tools to move issues between providers
+- Bi-directional sync between multiple providers
+- Support for self-hosted provider instances (may be added later)
+- Git operations (clone, push, pull) - only issue/PR/milestone management is abstracted
+
+## Dependencies
+
+- Existing GitHub service implementation (will be refactored into provider pattern)
+- Python httpx library for REST API calls
+- Provider authentication mechanisms (gh CLI for GitHub, PAT for Azure DevOps)

--- a/specs/044-git-provider-abstraction/tasks.md
+++ b/specs/044-git-provider-abstraction/tasks.md
@@ -1,0 +1,349 @@
+# Tasks: Git Provider Abstraction Layer
+
+**Input**: Design documents from `/specs/044-git-provider-abstraction/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓
+
+**Tests**: Not explicitly requested in specification - tests excluded by default.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Task Dependencies
+
+<!-- BEGIN:AUTO-GENERATED section="task-dependencies" -->
+```mermaid
+flowchart TD
+    subgraph "Phase 1: Setup"
+        T001[T001: Directory structure]
+        T002[T002: __init__.py files]
+    end
+
+    subgraph "Phase 2: Foundation"
+        T003[T003: Provider models]
+        T004[T004: Exception hierarchy]
+        T005[T005: GitProvider base]
+        T006[T006: ProviderFactory]
+        T007[T007: ProviderConfig]
+    end
+
+    subgraph "Phase 3: US1 - Configure Provider"
+        T008[T008: Provider detection]
+        T009[T009: CLI configure cmd]
+        T010[T010: CLI status cmd]
+        T011[T011: Integration tests]
+    end
+
+    subgraph "Phase 4: US2 - Create Issues"
+        T012[T012: GitHub create_issue]
+        T013[T013: GitHub label mapping]
+        T014[T014: ADO create_issue]
+        T015[T015: ADO label mapping]
+        T016[T016: GitLab stub]
+        T017[T017: Update github_service]
+    end
+
+    subgraph "Phase 5: US3 - Query Issues"
+        T018[T018: GitHub list_issues]
+        T019[T019: GitHub get_issue]
+        T020[T020: ADO list_issues]
+        T021[T021: ADO get_issue]
+    end
+
+    subgraph "Phase 6: US4 - Pull Requests"
+        T022[T022: GitHub create_pr]
+        T023[T023: GitHub get_pr]
+        T024[T024: ADO create_pr]
+        T025[T025: ADO get_pr]
+    end
+
+    subgraph "Phase 7: US5 - Milestones"
+        T026[T026: GitHub milestones]
+        T027[T027: ADO iterations]
+    end
+
+    subgraph "Phase 8: Polish"
+        T028[T028: Rate limiting]
+        T029[T029: Offline mode]
+        T030[T030: Error messages]
+        T031[T031: Documentation]
+    end
+
+    T001 --> T002 --> T003
+    T003 --> T004 & T005
+    T004 & T005 --> T006 & T007
+    T006 & T007 --> T008
+    T008 --> T009 & T010
+    T009 & T010 --> T011
+    T011 --> T012
+    T012 --> T013 --> T014
+    T014 --> T015 --> T016 --> T017
+    T017 --> T018
+    T018 --> T019 --> T020 --> T021
+    T021 --> T022
+    T022 --> T023 --> T024 --> T025
+    T025 --> T026 --> T027
+    T027 --> T028 --> T029 --> T030 --> T031
+```
+<!-- END:AUTO-GENERATED -->
+
+## Phase Timeline
+
+<!-- BEGIN:AUTO-GENERATED section="phase-timeline" -->
+```mermaid
+gantt
+    title Implementation Phases
+    dateFormat YYYY-MM-DD
+
+    section Phase 1: Setup
+    Directory and init files    :a1, 2026-01-23, 1d
+
+    section Phase 2: Foundation
+    Models and base classes     :b1, after a1, 2d
+
+    section Phase 3: US1 Configure (P1)
+    Provider configuration      :c1, after b1, 2d
+
+    section Phase 4: US2 Issues (P1)
+    Issue creation abstraction  :c2, after c1, 3d
+
+    section Phase 5: US3 Query (P2)
+    Issue querying              :d1, after c2, 2d
+
+    section Phase 6: US4 PRs (P2)
+    Pull request management     :d2, after d1, 2d
+
+    section Phase 7: US5 Milestones (P3)
+    Milestone synchronization   :e1, after d2, 1d
+
+    section Phase 8: Polish
+    Error handling & docs       :f1, after e1, 2d
+```
+<!-- END:AUTO-GENERATED -->
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Project type**: Single CLI application
+- **Source**: `src/doit_cli/`
+- **Tests**: `tests/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create directory structure for provider abstraction
+
+- [x] T001 Create provider directory structure: `src/doit_cli/services/providers/`
+- [x] T002 [P] Create `__init__.py` files for new modules in `src/doit_cli/services/providers/__init__.py` and `src/doit_cli/models/__init__.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Create provider-agnostic data models (Issue, PullRequest, Milestone, Label, enums) in `src/doit_cli/models/provider_models.py` based on data-model.md
+- [x] T004 [P] Create exception hierarchy (ProviderError, AuthenticationError, RateLimitError, ResourceNotFoundError, ValidationError, NetworkError) in `src/doit_cli/services/providers/exceptions.py`
+- [x] T005 [P] Create GitProvider abstract base class with all operations in `src/doit_cli/services/providers/base.py` based on contracts/provider_interface.py
+- [x] T006 Create ProviderFactory with auto-detection logic in `src/doit_cli/services/provider_factory.py`
+- [x] T007 [P] Create ProviderConfig for YAML configuration management in `src/doit_cli/services/provider_config.py`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Configure Git Provider (Priority: P1) 🎯 MVP
+
+**Goal**: Enable developers to specify and configure their git provider so CLI knows how to interact with their repository
+
+**Independent Test**: Configure a provider and verify the configuration is persisted and loaded correctly on subsequent CLI invocations
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Implement provider auto-detection from git remote URL in `src/doit_cli/services/provider_factory.py` (detect GitHub, Azure DevOps, GitLab patterns)
+- [x] T009 [US1] Create `doit provider configure` CLI command with interactive provider selection in `src/doit_cli/cli/provider.py`
+- [x] T010 [P] [US1] Create `doit provider status` CLI command to show current provider configuration in `src/doit_cli/cli/provider.py`
+- [x] T011 [US1] Add provider commands to main CLI app in `src/doit_cli/cli/main.py`
+
+**Checkpoint**: User Story 1 complete - users can configure and verify their git provider
+
+---
+
+## Phase 4: User Story 2 - Create Issues and Epics (Priority: P1)
+
+**Goal**: Enable issue/epic creation through abstraction layer regardless of provider
+
+**Independent Test**: Create an epic and issue through the abstraction layer and verify they appear correctly in the provider's web interface
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Implement `create_issue` method in GitHubProvider using gh CLI in `src/doit_cli/services/providers/github.py`
+- [x] T013 [US2] Implement label translation for GitHub (epic labels, priority mapping) in `src/doit_cli/services/providers/github.py`
+- [x] T014 [US2] Implement `create_issue` method in AzureDevOpsProvider using REST API in `src/doit_cli/services/providers/azure_devops.py`
+- [x] T015 [US2] Implement label/tag translation for Azure DevOps (work item types, tags) in `src/doit_cli/services/providers/azure_devops.py`
+- [x] T016 [P] [US2] Create GitLabProvider stub with NotImplementedError and guidance in `src/doit_cli/services/providers/gitlab.py`
+- [x] T017 [US2] Refactor existing `github_service.py` to delegate to GitHubProvider while maintaining backward compatibility in `src/doit_cli/services/github_service.py`
+
+**Checkpoint**: User Story 2 complete - issues can be created through abstraction on GitHub and Azure DevOps
+
+---
+
+## Phase 5: User Story 3 - Query Issues and Status (Priority: P2)
+
+**Goal**: Enable querying issue status from git provider for display in CLI commands
+
+**Independent Test**: Query existing issues through the abstraction and verify returned data matches provider's web interface
+
+### Implementation for User Story 3
+
+- [x] T018 [US3] Implement `list_issues` method in GitHubProvider with filtering support in `src/doit_cli/services/providers/github.py`
+- [x] T019 [P] [US3] Implement `get_issue` method in GitHubProvider in `src/doit_cli/services/providers/github.py`
+- [x] T020 [US3] Implement `list_issues` method in AzureDevOpsProvider with work item query in `src/doit_cli/services/providers/azure_devops.py`
+- [x] T021 [P] [US3] Implement `get_issue` method in AzureDevOpsProvider in `src/doit_cli/services/providers/azure_devops.py`
+
+**Checkpoint**: User Story 3 complete - issue status can be queried and displayed
+
+---
+
+## Phase 6: User Story 4 - Manage Pull Requests / Merge Requests (Priority: P2)
+
+**Goal**: Enable PR/MR creation through abstraction for `/doit.checkin` workflow
+
+**Independent Test**: Create a PR/MR through the abstraction and verify it appears correctly in the provider with correct branches and description
+
+### Implementation for User Story 4
+
+- [x] T022 [US4] Implement `create_pull_request` method in GitHubProvider using gh CLI in `src/doit_cli/services/providers/github.py`
+- [x] T023 [P] [US4] Implement `get_pull_request` and `list_pull_requests` methods in GitHubProvider in `src/doit_cli/services/providers/github.py`
+- [x] T024 [US4] Implement `create_pull_request` method in AzureDevOpsProvider using REST API in `src/doit_cli/services/providers/azure_devops.py`
+- [x] T025 [P] [US4] Implement `get_pull_request` and `list_pull_requests` methods in AzureDevOpsProvider in `src/doit_cli/services/providers/azure_devops.py`
+
+**Checkpoint**: User Story 4 complete - PRs/MRs can be created through abstraction
+
+---
+
+## Phase 7: User Story 5 - Manage Milestones (Priority: P3)
+
+**Goal**: Enable milestone synchronization with provider's milestone/iteration system
+
+**Independent Test**: Sync milestones and verify they appear correctly in provider's project board or milestone list
+
+### Implementation for User Story 5
+
+- [x] T026 [US5] Implement milestone operations (`create_milestone`, `get_milestone`, `list_milestones`) in GitHubProvider in `src/doit_cli/services/providers/github.py`
+- [x] T027 [US5] Implement iteration operations (mapped as milestones) in AzureDevOpsProvider in `src/doit_cli/services/providers/azure_devops.py`
+
+**Checkpoint**: User Story 5 complete - milestones can be synced across providers
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T028 Implement rate limit handling with exponential backoff in `src/doit_cli/services/providers/base.py`
+- [x] T029 [P] Implement offline mode graceful degradation in `src/doit_cli/services/provider_factory.py`
+- [x] T030 [P] Improve error messages for authentication failures in `src/doit_cli/services/providers/exceptions.py`
+- [x] T031 Update documentation with provider configuration guide in `docs/features/044-git-provider-abstraction.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Foundational phase completion
+  - US1 (Configure) must complete before other user stories
+  - US2-US5 can proceed in priority order
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1 - Configure)**: BLOCKS all other stories - configuration required first
+- **User Story 2 (P1 - Issues)**: Depends on US1 - can start after US1 completes
+- **User Story 3 (P2 - Query)**: Depends on US2 - builds on issue infrastructure
+- **User Story 4 (P2 - PRs)**: Can start after US1, independent of US2/US3
+- **User Story 5 (P3 - Milestones)**: Can start after US1, independent of US2/US3/US4
+
+### Within Each User Story
+
+- Models before services
+- Services before CLI commands
+- GitHub implementation before Azure DevOps
+- Core implementation before refinements
+
+### Parallel Opportunities
+
+- T003 and T004/T005 can run in parallel (different files)
+- T006 and T007 can run in parallel (factory vs config)
+- T009 and T010 can run in parallel (different CLI commands)
+- T018/T019 and T020/T021 can run in parallel (different providers)
+- T022/T023 and T024/T025 can run in parallel (different providers)
+- T028, T029, T030 can all run in parallel (different concerns)
+
+---
+
+## Parallel Example: Phase 2 Foundation
+
+```bash
+# Launch foundation models in parallel:
+Task: "Create provider-agnostic data models in src/doit_cli/models/provider_models.py"
+
+# Then launch exception and base class in parallel:
+Task: "Create exception hierarchy in src/doit_cli/services/providers/exceptions.py"
+Task: "Create GitProvider abstract base class in src/doit_cli/services/providers/base.py"
+
+# Then launch factory and config in parallel:
+Task: "Create ProviderFactory in src/doit_cli/services/provider_factory.py"
+Task: "Create ProviderConfig in src/doit_cli/services/provider_config.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Configure Provider)
+4. Complete Phase 4: User Story 2 (Create Issues)
+5. **STOP and VALIDATE**: Test issue creation on GitHub and Azure DevOps
+6. Existing `doit roadmapit add` should work through abstraction
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Provider can be configured → Checkpoint
+3. Add User Story 2 → Issues can be created → Deploy/Demo (MVP!)
+4. Add User Story 3 → Issues can be queried → Deploy/Demo
+5. Add User Story 4 → PRs can be created → Deploy/Demo
+6. Add User Story 5 → Milestones can be synced → Deploy/Demo
+7. Each story adds value without breaking previous stories
+
+### Backward Compatibility Strategy
+
+- `github_service.py` continues to work as facade
+- Existing commands don't need modification
+- Provider abstraction is opt-in through configuration
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- GitHub provider uses `gh` CLI (existing pattern)
+- Azure DevOps provider uses REST API with httpx
+- GitLab is stub only (NotImplementedError with guidance)

--- a/src/doit_cli/cli/provider_command.py
+++ b/src/doit_cli/cli/provider_command.py
@@ -1,0 +1,234 @@
+"""CLI commands for git provider management.
+
+This module provides commands for configuring and managing
+git provider settings.
+"""
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ..services.provider_config import ProviderConfig
+from ..services.provider_factory import ProviderFactory
+from ..services.providers.base import ProviderType
+
+app = typer.Typer(
+    name="provider",
+    help="Git provider management commands",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+@app.command(name="configure")
+def configure_command(
+    provider: Optional[str] = typer.Option(
+        None,
+        "--provider",
+        "-p",
+        help="Provider to configure: github, azure_devops, gitlab",
+    ),
+    organization: Optional[str] = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Azure DevOps organization name",
+    ),
+    project: Optional[str] = typer.Option(
+        None,
+        "--project",
+        help="Azure DevOps project name",
+    ),
+    auto_detect: bool = typer.Option(
+        False,
+        "--auto-detect",
+        "-a",
+        help="Auto-detect provider from git remote URL",
+    ),
+) -> None:
+    """Configure the git provider for this project.
+
+    If no options are provided, the command will attempt to auto-detect
+    the provider from the git remote URL.
+
+    Examples:
+        # Auto-detect provider
+        doit provider configure --auto-detect
+
+        # Explicit GitHub
+        doit provider configure --provider github
+
+        # Azure DevOps
+        doit provider configure --provider azure_devops -o myorg --project myproject
+    """
+    config = ProviderConfig()
+
+    if provider:
+        # Explicit provider specified
+        try:
+            config.provider = ProviderType(provider.lower())
+            config.auto_detected = False
+        except ValueError:
+            console.print(
+                f"[red]Error: Unknown provider '{provider}'[/red]"
+            )
+            console.print(
+                "Valid providers: github, azure_devops, gitlab"
+            )
+            raise typer.Exit(code=1)
+
+    elif auto_detect or not provider:
+        # Auto-detect from git remote
+        detected = ProviderFactory.detect_provider()
+        if detected:
+            config.provider = detected
+            config.auto_detected = True
+            config.detection_source = "git_remote"
+            console.print(
+                f"[green]Auto-detected provider: {config.get_provider_display_name()}[/green]"
+            )
+        else:
+            # Interactive selection
+            console.print(
+                "[yellow]Could not auto-detect provider from git remote.[/yellow]"
+            )
+            console.print("\nAvailable providers:")
+            console.print("  1. GitHub")
+            console.print("  2. Azure DevOps")
+            console.print("  3. GitLab (stub - not fully implemented)")
+            console.print("  4. None (skip provider configuration)")
+
+            choice = typer.prompt(
+                "Select provider",
+                type=int,
+                default=1,
+            )
+
+            provider_map = {
+                1: ProviderType.GITHUB,
+                2: ProviderType.AZURE_DEVOPS,
+                3: ProviderType.GITLAB,
+            }
+
+            if choice == 4:
+                console.print("[yellow]Skipping provider configuration.[/yellow]")
+                return
+
+            if choice not in provider_map:
+                console.print("[red]Invalid choice[/red]")
+                raise typer.Exit(code=1)
+
+            config.provider = provider_map[choice]
+            config.auto_detected = False
+
+    # Handle Azure DevOps-specific configuration
+    if config.provider == ProviderType.AZURE_DEVOPS:
+        if not organization:
+            organization = typer.prompt("Azure DevOps organization")
+        if not project:
+            project = typer.prompt("Azure DevOps project")
+
+        config.azure_devops.organization = organization
+        config.azure_devops.project = project
+
+    # Save configuration
+    config.save()
+
+    console.print(
+        Panel(
+            f"[green]Provider configured: {config.get_provider_display_name()}[/green]",
+            title="Configuration Saved",
+        )
+    )
+
+    # Show next steps
+    console.print("\n[dim]Next steps:[/dim]")
+    if config.provider == ProviderType.GITHUB:
+        console.print("  • Ensure you're authenticated: gh auth status")
+    elif config.provider == ProviderType.AZURE_DEVOPS:
+        console.print("  • Set AZURE_DEVOPS_PAT environment variable with your Personal Access Token")
+    elif config.provider == ProviderType.GITLAB:
+        console.print("  • [yellow]Note: GitLab support is not fully implemented yet[/yellow]")
+        console.print("  • Set GITLAB_TOKEN environment variable when available")
+
+
+@app.command(name="status")
+def status_command() -> None:
+    """Show current provider configuration and status.
+
+    Displays the configured provider, its settings, and
+    whether it's currently available.
+    """
+    config = ProviderConfig.load()
+
+    # Create status table
+    table = Table(title="Git Provider Status", show_header=False)
+    table.add_column("Property", style="cyan")
+    table.add_column("Value")
+
+    # Provider info
+    table.add_row("Provider", config.get_provider_display_name())
+    table.add_row("Auto-detected", "Yes" if config.auto_detected else "No")
+
+    if config.detection_source:
+        table.add_row("Detection source", config.detection_source)
+
+    # Provider-specific info
+    if config.provider == ProviderType.AZURE_DEVOPS:
+        table.add_row("Organization", config.azure_devops.organization or "[dim]Not set[/dim]")
+        table.add_row("Project", config.azure_devops.project or "[dim]Not set[/dim]")
+
+    # Check availability
+    if config.provider:
+        try:
+            provider = ProviderFactory.create(config)
+            available = provider.is_available
+            table.add_row(
+                "Available",
+                "[green]✓ Yes[/green]" if available else "[red]✗ No[/red]"
+            )
+        except Exception as e:
+            table.add_row("Available", f"[red]✗ Error: {e}[/red]")
+    else:
+        table.add_row("Available", "[dim]N/A (no provider configured)[/dim]")
+
+    console.print(table)
+
+    # Show configuration file path
+    console.print(
+        f"\n[dim]Configuration file: {ProviderConfig.CONFIG_PATH}[/dim]"
+    )
+
+
+@app.command(name="detect")
+def detect_command() -> None:
+    """Auto-detect the git provider from the repository remote.
+
+    Examines the git remote URL and reports which provider
+    would be detected without saving configuration.
+    """
+    detected = ProviderFactory.detect_provider()
+
+    if detected:
+        names = {
+            ProviderType.GITHUB: "GitHub",
+            ProviderType.AZURE_DEVOPS: "Azure DevOps",
+            ProviderType.GITLAB: "GitLab",
+        }
+        console.print(
+            f"[green]Detected provider: {names.get(detected, detected.value)}[/green]"
+        )
+        console.print(
+            "\n[dim]Run 'doit provider configure --auto-detect' to save this configuration.[/dim]"
+        )
+    else:
+        console.print(
+            "[yellow]Could not detect provider from git remote URL.[/yellow]"
+        )
+        console.print(
+            "\n[dim]Run 'doit provider configure' to manually select a provider.[/dim]"
+        )

--- a/src/doit_cli/main.py
+++ b/src/doit_cli/main.py
@@ -9,6 +9,7 @@ from .cli.fixit_command import app as fixit_app
 from .cli.hooks_command import hooks_app
 from .cli.init_command import init_command
 from .cli.memory_command import memory_app
+from .cli.provider_command import app as provider_app
 from .cli.roadmapit_command import app as roadmapit_app
 from .cli.status_command import status_command
 from .cli.sync_prompts_command import sync_prompts_command
@@ -39,6 +40,7 @@ app.add_typer(diagram_app, name="diagram")
 app.add_typer(fixit_app, name="fixit")
 app.add_typer(hooks_app, name="hooks")
 app.add_typer(memory_app, name="memory")
+app.add_typer(provider_app, name="provider")
 app.add_typer(roadmapit_app, name="roadmapit")
 app.add_typer(team_app, name="team")
 app.add_typer(xref_app, name="xref")

--- a/src/doit_cli/models/provider_models.py
+++ b/src/doit_cli/models/provider_models.py
@@ -1,0 +1,170 @@
+"""Provider-agnostic data models for git operations.
+
+This module defines unified data models that work across all git providers
+(GitHub, Azure DevOps, GitLab).
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class IssueType(Enum):
+    """Unified issue type classification."""
+
+    BUG = "bug"
+    TASK = "task"
+    USER_STORY = "user_story"
+    FEATURE = "feature"
+    EPIC = "epic"
+
+
+class IssueState(Enum):
+    """Issue state."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class PRState(Enum):
+    """Pull request state."""
+
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"
+
+
+class MilestoneState(Enum):
+    """Milestone state."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass
+class Label:
+    """A label/tag that can be applied to issues and pull requests."""
+
+    name: str
+    color: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class Issue:
+    """Unified issue representation across all providers."""
+
+    id: str  # Unified ID: {provider}:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    state: IssueState
+    url: str
+    created_at: datetime
+    updated_at: datetime
+    body: Optional[str] = None
+    type: IssueType = IssueType.TASK
+    labels: list[Label] = field(default_factory=list)
+    milestone_id: Optional[str] = None
+
+
+@dataclass
+class PullRequest:
+    """Unified pull request / merge request representation."""
+
+    id: str  # Unified ID: {provider}:pr:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    source_branch: str
+    target_branch: str
+    state: PRState
+    url: str
+    created_at: datetime
+    body: Optional[str] = None
+    labels: list[Label] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)  # Issue IDs
+    merged_at: Optional[datetime] = None
+
+
+@dataclass
+class Milestone:
+    """Unified milestone / iteration / sprint representation."""
+
+    id: str  # Unified ID: {provider}:ms:{provider_id}
+    provider_id: str  # Provider-specific ID
+    title: str
+    state: MilestoneState
+    description: Optional[str] = None
+    due_date: Optional[datetime] = None
+    issue_count: int = 0
+    closed_issue_count: int = 0
+    url: Optional[str] = None
+
+
+# =============================================================================
+# Request Models
+# =============================================================================
+
+
+@dataclass
+class IssueCreateRequest:
+    """Request to create a new issue."""
+
+    title: str
+    body: Optional[str] = None
+    type: IssueType = IssueType.TASK
+    labels: list[str] = field(default_factory=list)
+    milestone_id: Optional[str] = None
+
+
+@dataclass
+class IssueUpdateRequest:
+    """Request to update an existing issue."""
+
+    title: Optional[str] = None
+    body: Optional[str] = None
+    state: Optional[IssueState] = None
+    labels: Optional[list[str]] = None
+    milestone_id: Optional[str] = None
+
+
+@dataclass
+class IssueFilters:
+    """Filters for querying issues."""
+
+    state: Optional[IssueState] = None
+    labels: Optional[list[str]] = None
+    milestone_id: Optional[str] = None
+    type: Optional[IssueType] = None
+    limit: int = 100
+
+
+@dataclass
+class PRCreateRequest:
+    """Request to create a new pull request."""
+
+    title: str
+    source_branch: str
+    target_branch: str = "main"
+    body: Optional[str] = None
+    labels: list[str] = field(default_factory=list)
+    closes_issues: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PRFilters:
+    """Filters for querying pull requests."""
+
+    state: Optional[PRState] = None
+    source_branch: Optional[str] = None
+    target_branch: Optional[str] = None
+    limit: int = 100
+
+
+@dataclass
+class MilestoneCreateRequest:
+    """Request to create a new milestone."""
+
+    title: str
+    description: Optional[str] = None
+    due_date: Optional[datetime] = None

--- a/src/doit_cli/services/provider_config.py
+++ b/src/doit_cli/services/provider_config.py
@@ -1,0 +1,196 @@
+"""Provider configuration management.
+
+This module handles loading, saving, and managing provider
+configuration stored in .doit/config/provider.yaml.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .providers.base import ProviderType
+
+
+@dataclass
+class AzureDevOpsConfig:
+    """Azure DevOps-specific configuration."""
+
+    organization: str = ""
+    project: str = ""
+    auth_method: str = "pat"  # personal access token
+    api_version: str = "7.0"
+
+
+@dataclass
+class GitHubConfig:
+    """GitHub-specific configuration."""
+
+    auth_method: str = "gh_cli"  # or "token"
+    enterprise_host: Optional[str] = None
+
+
+@dataclass
+class GitLabConfig:
+    """GitLab-specific configuration."""
+
+    host: str = "gitlab.com"
+    auth_method: str = "token"
+
+
+@dataclass
+class ProviderConfig:
+    """Provider configuration.
+
+    Manages configuration for git providers, stored in
+    .doit/config/provider.yaml.
+
+    Attributes:
+        provider: The configured provider type.
+        auto_detected: Whether the provider was auto-detected.
+        detection_source: How the provider was detected (e.g., "git_remote").
+        github: GitHub-specific configuration.
+        azure_devops: Azure DevOps-specific configuration.
+        gitlab: GitLab-specific configuration.
+    """
+
+    provider: Optional[ProviderType] = None
+    auto_detected: bool = False
+    detection_source: Optional[str] = None
+    github: GitHubConfig = field(default_factory=GitHubConfig)
+    azure_devops: AzureDevOpsConfig = field(default_factory=AzureDevOpsConfig)
+    gitlab: GitLabConfig = field(default_factory=GitLabConfig)
+
+    CONFIG_PATH: Path = Path(".doit/config/provider.yaml")
+
+    @classmethod
+    def load(cls, config_path: Optional[Path] = None) -> "ProviderConfig":
+        """Load configuration from file.
+
+        Args:
+            config_path: Optional custom path. Defaults to .doit/config/provider.yaml
+
+        Returns:
+            ProviderConfig instance, empty if file doesn't exist.
+        """
+        path = config_path or cls.CONFIG_PATH
+
+        if not path.exists():
+            return cls()
+
+        try:
+            with open(path) as f:
+                data = yaml.safe_load(f) or {}
+        except (yaml.YAMLError, OSError):
+            return cls()
+
+        config = cls()
+
+        # Parse provider type
+        if "provider" in data:
+            try:
+                config.provider = ProviderType(data["provider"])
+            except ValueError:
+                pass
+
+        config.auto_detected = data.get("auto_detected", False)
+        config.detection_source = data.get("detection_source")
+
+        # Parse GitHub config
+        if "github" in data:
+            gh = data["github"]
+            config.github = GitHubConfig(
+                auth_method=gh.get("auth_method", "gh_cli"),
+                enterprise_host=gh.get("enterprise_host"),
+            )
+
+        # Parse Azure DevOps config
+        if "azure_devops" in data:
+            ado = data["azure_devops"]
+            config.azure_devops = AzureDevOpsConfig(
+                organization=ado.get("organization", ""),
+                project=ado.get("project", ""),
+                auth_method=ado.get("auth_method", "pat"),
+                api_version=ado.get("api_version", "7.0"),
+            )
+
+        # Parse GitLab config
+        if "gitlab" in data:
+            gl = data["gitlab"]
+            config.gitlab = GitLabConfig(
+                host=gl.get("host", "gitlab.com"),
+                auth_method=gl.get("auth_method", "token"),
+            )
+
+        return config
+
+    def save(self, config_path: Optional[Path] = None) -> None:
+        """Save configuration to file.
+
+        Args:
+            config_path: Optional custom path. Defaults to .doit/config/provider.yaml
+        """
+        path = config_path or self.CONFIG_PATH
+
+        # Ensure directory exists
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data: dict[str, Any] = {}
+
+        if self.provider:
+            data["provider"] = self.provider.value
+
+        data["auto_detected"] = self.auto_detected
+
+        if self.detection_source:
+            data["detection_source"] = self.detection_source
+
+        # Save provider-specific config based on selected provider
+        if self.provider == ProviderType.GITHUB:
+            data["github"] = {
+                "auth_method": self.github.auth_method,
+            }
+            if self.github.enterprise_host:
+                data["github"]["enterprise_host"] = self.github.enterprise_host
+
+        elif self.provider == ProviderType.AZURE_DEVOPS:
+            data["azure_devops"] = {
+                "organization": self.azure_devops.organization,
+                "project": self.azure_devops.project,
+                "auth_method": self.azure_devops.auth_method,
+                "api_version": self.azure_devops.api_version,
+            }
+
+        elif self.provider == ProviderType.GITLAB:
+            data["gitlab"] = {
+                "host": self.gitlab.host,
+                "auth_method": self.gitlab.auth_method,
+            }
+
+        with open(path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def is_configured(self) -> bool:
+        """Check if a provider is configured.
+
+        Returns:
+            True if a provider is set, False otherwise.
+        """
+        return self.provider is not None
+
+    def get_provider_display_name(self) -> str:
+        """Get a human-readable name for the configured provider.
+
+        Returns:
+            Display name or "Not configured" if no provider is set.
+        """
+        if self.provider is None:
+            return "Not configured"
+
+        names = {
+            ProviderType.GITHUB: "GitHub",
+            ProviderType.AZURE_DEVOPS: "Azure DevOps",
+            ProviderType.GITLAB: "GitLab",
+        }
+        return names.get(self.provider, self.provider.value)

--- a/src/doit_cli/services/provider_factory.py
+++ b/src/doit_cli/services/provider_factory.py
@@ -1,0 +1,186 @@
+"""Factory for creating git provider instances.
+
+This module provides the ProviderFactory class for instantiating
+the appropriate git provider based on configuration.
+"""
+
+import subprocess
+from typing import TYPE_CHECKING, Optional
+
+from .providers.base import GitProvider, ProviderType
+from .providers.exceptions import ProviderError, ProviderNotConfiguredError
+
+if TYPE_CHECKING:
+    from .provider_config import ProviderConfig
+
+
+class ProviderFactory:
+    """Factory for creating the appropriate git provider.
+
+    This factory handles provider instantiation based on configuration,
+    with fallback to auto-detection from git remote URL.
+
+    Usage:
+        # With auto-detection
+        provider = ProviderFactory.create()
+
+        # With explicit configuration
+        config = ProviderConfig.load()
+        provider = ProviderFactory.create(config)
+    """
+
+    @classmethod
+    def create(cls, config: Optional["ProviderConfig"] = None) -> GitProvider:
+        """Create a provider instance based on configuration.
+
+        Args:
+            config: Optional provider configuration. If not provided,
+                   configuration is loaded from file or auto-detected.
+
+        Returns:
+            GitProvider instance for the configured provider.
+
+        Raises:
+            ProviderNotConfiguredError: If no provider is configured or detected.
+            ProviderError: If provider instantiation fails.
+        """
+        from .provider_config import ProviderConfig
+
+        if config is None:
+            config = ProviderConfig.load()
+
+        # Get provider type from config or auto-detect
+        provider_type = config.provider
+        if provider_type is None:
+            provider_type = cls.detect_provider()
+            if provider_type is None:
+                raise ProviderNotConfiguredError()
+
+        # Instantiate the appropriate provider
+        if provider_type == ProviderType.GITHUB:
+            from .providers.github import GitHubProvider
+
+            return GitHubProvider()
+
+        elif provider_type == ProviderType.AZURE_DEVOPS:
+            from .providers.azure_devops import AzureDevOpsProvider
+
+            return AzureDevOpsProvider(config.azure_devops)
+
+        elif provider_type == ProviderType.GITLAB:
+            from .providers.gitlab import GitLabProvider
+
+            return GitLabProvider()
+
+        else:
+            raise ProviderError(f"Unknown provider type: {provider_type}")
+
+    @classmethod
+    def detect_provider(cls) -> Optional[ProviderType]:
+        """Auto-detect provider from git remote URL.
+
+        Examines the origin remote URL to determine which git hosting
+        provider is being used.
+
+        Returns:
+            ProviderType if detected, None if detection fails.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+            if result.returncode != 0:
+                return None
+
+            remote_url = result.stdout.strip().lower()
+
+            # Check for GitHub (including enterprise)
+            if "github.com" in remote_url or "ghe." in remote_url:
+                return ProviderType.GITHUB
+
+            # Check for Azure DevOps
+            if "dev.azure.com" in remote_url or "visualstudio.com" in remote_url:
+                return ProviderType.AZURE_DEVOPS
+
+            # Check for GitLab (including self-hosted)
+            if "gitlab" in remote_url:
+                return ProviderType.GITLAB
+
+            return None
+
+        except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+            return None
+
+    @classmethod
+    def is_provider_available(cls, provider_type: ProviderType) -> bool:
+        """Check if a specific provider is available.
+
+        Args:
+            provider_type: The provider type to check.
+
+        Returns:
+            True if the provider is available, False otherwise.
+        """
+        try:
+            from .provider_config import ProviderConfig
+
+            config = ProviderConfig()
+            config.provider = provider_type
+
+            provider = cls.create(config)
+            return provider.is_available
+        except (ProviderError, ImportError):
+            return False
+
+    @classmethod
+    def is_offline(cls) -> bool:
+        """Check if we're in offline mode (no network connectivity).
+
+        Returns:
+            True if offline, False if online.
+        """
+        try:
+            # Try a simple network check
+            import socket
+
+            socket.setdefaulttimeout(3)
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(
+                ("github.com", 443)
+            )
+            return False
+        except (socket.error, socket.timeout, OSError):
+            return True
+
+    @classmethod
+    def create_safe(
+        cls, config: Optional["ProviderConfig"] = None
+    ) -> Optional[GitProvider]:
+        """Create a provider instance, returning None if unavailable.
+
+        This method is useful for offline-safe operations where
+        provider features are optional.
+
+        Args:
+            config: Optional provider configuration.
+
+        Returns:
+            GitProvider instance if available, None otherwise.
+
+        Example:
+            provider = ProviderFactory.create_safe()
+            if provider:
+                issues = provider.list_issues()
+            else:
+                print("Running in offline mode")
+        """
+        try:
+            provider = cls.create(config)
+            if provider.is_available:
+                return provider
+            return None
+        except (ProviderError, ProviderNotConfiguredError):
+            return None

--- a/src/doit_cli/services/providers/__init__.py
+++ b/src/doit_cli/services/providers/__init__.py
@@ -1,0 +1,26 @@
+"""Git provider implementations.
+
+This package contains the provider abstraction layer for git hosting platforms
+including GitHub, Azure DevOps, and GitLab.
+"""
+
+from .base import GitProvider, ProviderType
+from .exceptions import (
+    AuthenticationError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+__all__ = [
+    "GitProvider",
+    "ProviderType",
+    "ProviderError",
+    "AuthenticationError",
+    "RateLimitError",
+    "ResourceNotFoundError",
+    "ValidationError",
+    "NetworkError",
+]

--- a/src/doit_cli/services/providers/azure_devops.py
+++ b/src/doit_cli/services/providers/azure_devops.py
@@ -1,0 +1,745 @@
+"""Azure DevOps provider implementation using REST API.
+
+This module implements the GitProvider interface for Azure DevOps
+using direct REST API calls via httpx.
+"""
+
+import os
+from datetime import datetime
+from typing import Any, Optional
+
+import httpx
+
+from ...models.provider_models import (
+    Issue,
+    IssueCreateRequest,
+    IssueFilters,
+    IssueState,
+    IssueType,
+    IssueUpdateRequest,
+    Label,
+    Milestone,
+    MilestoneCreateRequest,
+    MilestoneState,
+    PullRequest,
+    PRCreateRequest,
+    PRFilters,
+    PRState,
+)
+from ..provider_config import AzureDevOpsConfig
+from .base import GitProvider, ProviderType
+from .exceptions import (
+    AuthenticationError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+
+class AzureDevOpsLabelMapper:
+    """Maps labels between unified format and Azure DevOps work item types/tags."""
+
+    # Issue type to Azure DevOps work item type
+    TYPE_TO_WORK_ITEM_TYPE = {
+        IssueType.BUG: "Bug",
+        IssueType.TASK: "Task",
+        IssueType.USER_STORY: "User Story",
+        IssueType.FEATURE: "Feature",
+        IssueType.EPIC: "Epic",
+    }
+
+    # Reverse mapping
+    WORK_ITEM_TYPE_TO_TYPE = {
+        "Bug": IssueType.BUG,
+        "Task": IssueType.TASK,
+        "User Story": IssueType.USER_STORY,
+        "Feature": IssueType.FEATURE,
+        "Epic": IssueType.EPIC,
+    }
+
+    @classmethod
+    def type_to_work_item_type(cls, issue_type: IssueType) -> str:
+        """Convert issue type to Azure DevOps work item type."""
+        return cls.TYPE_TO_WORK_ITEM_TYPE.get(issue_type, "Task")
+
+    @classmethod
+    def work_item_type_to_type(cls, work_item_type: str) -> IssueType:
+        """Convert Azure DevOps work item type to issue type."""
+        return cls.WORK_ITEM_TYPE_TO_TYPE.get(work_item_type, IssueType.TASK)
+
+
+class AzureDevOpsProvider(GitProvider):
+    """Azure DevOps implementation using REST API.
+
+    This provider uses the Azure DevOps REST API directly,
+    authenticated via Personal Access Token (PAT).
+    """
+
+    def __init__(self, config: Optional[AzureDevOpsConfig] = None, timeout: int = 30):
+        """Initialize the Azure DevOps provider.
+
+        Args:
+            config: Azure DevOps configuration with org/project.
+            timeout: Timeout in seconds for API requests.
+        """
+        self.config = config or AzureDevOpsConfig()
+        self.timeout = timeout
+        self._client: Optional[httpx.Client] = None
+
+    @property
+    def provider_type(self) -> ProviderType:
+        return ProviderType.AZURE_DEVOPS
+
+    @property
+    def name(self) -> str:
+        return "Azure DevOps"
+
+    @property
+    def is_available(self) -> bool:
+        """Check if Azure DevOps is configured and accessible."""
+        if not self.config.organization or not self.config.project:
+            return False
+        if not self._get_pat():
+            return False
+        try:
+            # Try to access the project
+            client = self._get_client()
+            response = client.get(
+                f"https://dev.azure.com/{self.config.organization}/_apis/projects/{self.config.project}",
+                params={"api-version": self.config.api_version},
+            )
+            return response.status_code == 200
+        except Exception:
+            return False
+
+    # -------------------------------------------------------------------------
+    # Issue Operations (Work Items)
+    # -------------------------------------------------------------------------
+
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        """Create a new Azure DevOps work item."""
+        self._ensure_authenticated()
+
+        work_item_type = AzureDevOpsLabelMapper.type_to_work_item_type(request.type)
+
+        # Build the JSON patch document
+        operations = [
+            {"op": "add", "path": "/fields/System.Title", "value": request.title},
+        ]
+
+        if request.body:
+            operations.append(
+                {"op": "add", "path": "/fields/System.Description", "value": request.body}
+            )
+
+        # Add tags from labels
+        if request.labels:
+            tags = "; ".join(request.labels)
+            operations.append(
+                {"op": "add", "path": "/fields/System.Tags", "value": tags}
+            )
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/workitems/${work_item_type}"
+            )
+
+            response = client.post(
+                url,
+                params={"api-version": self.config.api_version},
+                json=operations,
+                headers={"Content-Type": "application/json-patch+json"},
+            )
+
+            if response.status_code == 401:
+                raise AuthenticationError(
+                    "Azure DevOps authentication failed. Check your PAT.",
+                    provider="Azure DevOps",
+                )
+            elif response.status_code == 400:
+                raise ValidationError(f"Invalid work item: {response.text}")
+            elif response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_work_item(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """Get an Azure DevOps work item by ID."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/workitems/{provider_id}"
+            )
+
+            response = client.get(
+                url,
+                params={"api-version": self.config.api_version},
+            )
+
+            if response.status_code == 404:
+                raise ResourceNotFoundError("Work Item", provider_id)
+            elif response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_work_item(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def list_issues(self, filters: Optional[IssueFilters] = None) -> list[Issue]:
+        """List Azure DevOps work items matching filters."""
+        self._ensure_authenticated()
+
+        # Build WIQL query
+        conditions = []
+
+        if filters:
+            if filters.state:
+                state_str = "Active" if filters.state == IssueState.OPEN else "Closed"
+                conditions.append(f"[System.State] = '{state_str}'")
+
+            if filters.type:
+                work_item_type = AzureDevOpsLabelMapper.type_to_work_item_type(filters.type)
+                conditions.append(f"[System.WorkItemType] = '{work_item_type}'")
+
+            if filters.labels:
+                for label in filters.labels:
+                    conditions.append(f"[System.Tags] CONTAINS '{label}'")
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+        wiql = f"SELECT [System.Id] FROM WorkItems WHERE {where_clause}"
+
+        if filters and filters.limit:
+            wiql += f" ORDER BY [System.Id] DESC"
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/wiql"
+            )
+
+            response = client.post(
+                url,
+                params={"api-version": self.config.api_version},
+                json={"query": wiql},
+            )
+
+            if response.status_code != 200:
+                raise ProviderError(f"Azure DevOps query error: {response.text}")
+
+            data = response.json()
+            work_items = data.get("workItems", [])
+
+            # Limit results
+            if filters and filters.limit:
+                work_items = work_items[:filters.limit]
+
+            # Fetch full details for each work item
+            issues = []
+            for wi in work_items:
+                try:
+                    issue = self.get_issue(str(wi["id"]))
+                    issues.append(issue)
+                except ResourceNotFoundError:
+                    continue
+
+            return issues
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        """Update an Azure DevOps work item."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        operations = []
+
+        if updates.title:
+            operations.append(
+                {"op": "replace", "path": "/fields/System.Title", "value": updates.title}
+            )
+
+        if updates.body:
+            operations.append(
+                {"op": "replace", "path": "/fields/System.Description", "value": updates.body}
+            )
+
+        if updates.state:
+            state_str = "Active" if updates.state == IssueState.OPEN else "Closed"
+            operations.append(
+                {"op": "replace", "path": "/fields/System.State", "value": state_str}
+            )
+
+        if updates.labels is not None:
+            tags = "; ".join(updates.labels)
+            operations.append(
+                {"op": "replace", "path": "/fields/System.Tags", "value": tags}
+            )
+
+        if not operations:
+            return self.get_issue(provider_id)
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/workitems/{provider_id}"
+            )
+
+            response = client.patch(
+                url,
+                params={"api-version": self.config.api_version},
+                json=operations,
+                headers={"Content-Type": "application/json-patch+json"},
+            )
+
+            if response.status_code == 404:
+                raise ResourceNotFoundError("Work Item", provider_id)
+            elif response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_work_item(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    # -------------------------------------------------------------------------
+    # Pull Request Operations
+    # -------------------------------------------------------------------------
+
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        """Create a new Azure DevOps pull request."""
+        self._ensure_authenticated()
+
+        repo_id = self._get_repository_id()
+
+        body: dict[str, Any] = {
+            "sourceRefName": f"refs/heads/{request.source_branch}",
+            "targetRefName": f"refs/heads/{request.target_branch}",
+            "title": request.title,
+        }
+
+        if request.body:
+            body["description"] = request.body
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/git/repositories/{repo_id}/pullrequests"
+            )
+
+            response = client.post(
+                url,
+                params={"api-version": self.config.api_version},
+                json=body,
+            )
+
+            if response.status_code == 409:
+                raise ValidationError("Pull request already exists for this branch")
+            elif response.status_code not in (200, 201):
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_pull_request(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        """Get an Azure DevOps pull request by ID."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(pr_id)
+        repo_id = self._get_repository_id()
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/git/repositories/{repo_id}/pullrequests/{provider_id}"
+            )
+
+            response = client.get(
+                url,
+                params={"api-version": self.config.api_version},
+            )
+
+            if response.status_code == 404:
+                raise ResourceNotFoundError("Pull Request", provider_id)
+            elif response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_pull_request(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def list_pull_requests(
+        self, filters: Optional[PRFilters] = None
+    ) -> list[PullRequest]:
+        """List Azure DevOps pull requests matching filters."""
+        self._ensure_authenticated()
+        repo_id = self._get_repository_id()
+
+        params: dict[str, Any] = {"api-version": self.config.api_version}
+
+        if filters:
+            if filters.state:
+                state_map = {
+                    PRState.OPEN: "active",
+                    PRState.MERGED: "completed",
+                    PRState.CLOSED: "abandoned",
+                }
+                params["searchCriteria.status"] = state_map.get(filters.state, "active")
+
+            if filters.source_branch:
+                params["searchCriteria.sourceRefName"] = f"refs/heads/{filters.source_branch}"
+
+            if filters.target_branch:
+                params["searchCriteria.targetRefName"] = f"refs/heads/{filters.target_branch}"
+
+            if filters.limit:
+                params["$top"] = filters.limit
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/git/repositories/{repo_id}/pullrequests"
+            )
+
+            response = client.get(url, params=params)
+
+            if response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return [self._parse_pull_request(pr) for pr in data.get("value", [])]
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    # -------------------------------------------------------------------------
+    # Milestone Operations (Iterations)
+    # -------------------------------------------------------------------------
+
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        """Create a new Azure DevOps iteration."""
+        self._ensure_authenticated()
+
+        body: dict[str, Any] = {
+            "name": request.title,
+        }
+
+        if request.due_date:
+            body["attributes"] = {
+                "finishDate": request.due_date.isoformat(),
+            }
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/classificationnodes/Iterations"
+            )
+
+            response = client.post(
+                url,
+                params={"api-version": self.config.api_version},
+                json=body,
+            )
+
+            if response.status_code == 409:
+                raise ValidationError(f"Iteration '{request.title}' already exists")
+            elif response.status_code not in (200, 201):
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_iteration(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        """Get an Azure DevOps iteration by ID."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(milestone_id)
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/classificationnodes/Iterations/{provider_id}"
+            )
+
+            response = client.get(
+                url,
+                params={"api-version": self.config.api_version, "$depth": "1"},
+            )
+
+            if response.status_code == 404:
+                raise ResourceNotFoundError("Iteration", provider_id)
+            elif response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            return self._parse_iteration(data)
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def list_milestones(
+        self, state: Optional[MilestoneState] = None
+    ) -> list[Milestone]:
+        """List Azure DevOps iterations."""
+        self._ensure_authenticated()
+
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/wit/classificationnodes/Iterations"
+            )
+
+            response = client.get(
+                url,
+                params={"api-version": self.config.api_version, "$depth": "2"},
+            )
+
+            if response.status_code != 200:
+                raise ProviderError(f"Azure DevOps error: {response.text}")
+
+            data = response.json()
+            milestones = []
+
+            # Parse root and children
+            if data.get("children"):
+                for child in data["children"]:
+                    milestone = self._parse_iteration(child)
+                    milestones.append(milestone)
+
+            return milestones
+
+        except httpx.TimeoutException:
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    # -------------------------------------------------------------------------
+    # Helper Methods
+    # -------------------------------------------------------------------------
+
+    def _get_pat(self) -> Optional[str]:
+        """Get Personal Access Token from environment."""
+        return os.environ.get("AZURE_DEVOPS_PAT")
+
+    def _ensure_authenticated(self) -> None:
+        """Verify Azure DevOps is configured."""
+        if not self.config.organization:
+            raise AuthenticationError(
+                "Azure DevOps organization not configured",
+                provider="Azure DevOps",
+            )
+        if not self.config.project:
+            raise AuthenticationError(
+                "Azure DevOps project not configured",
+                provider="Azure DevOps",
+            )
+        if not self._get_pat():
+            raise AuthenticationError(
+                "AZURE_DEVOPS_PAT environment variable not set",
+                provider="Azure DevOps",
+            )
+
+    def _get_client(self) -> httpx.Client:
+        """Get or create HTTP client with authentication."""
+        if self._client is None:
+            pat = self._get_pat()
+            self._client = httpx.Client(
+                timeout=self.timeout,
+                auth=("", pat or ""),
+            )
+        return self._client
+
+    def _get_repository_id(self) -> str:
+        """Get the repository ID for the current project."""
+        try:
+            client = self._get_client()
+            url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_apis/git/repositories"
+            )
+
+            response = client.get(
+                url,
+                params={"api-version": self.config.api_version},
+            )
+
+            if response.status_code != 200:
+                raise ProviderError("Failed to get repository list")
+
+            data = response.json()
+            repos = data.get("value", [])
+
+            if not repos:
+                raise ProviderError("No repositories found in project")
+
+            # Return the first repository ID
+            return repos[0]["id"]
+
+        except httpx.RequestError as e:
+            raise NetworkError(f"Azure DevOps network error: {e}")
+
+    def _parse_work_item(self, data: dict) -> Issue:
+        """Parse Azure DevOps work item into Issue model."""
+        fields = data.get("fields", {})
+
+        # Parse state
+        state_str = fields.get("System.State", "Active")
+        state = IssueState.OPEN if state_str in ("Active", "New") else IssueState.CLOSED
+
+        # Parse type
+        work_item_type = fields.get("System.WorkItemType", "Task")
+        issue_type = AzureDevOpsLabelMapper.work_item_type_to_type(work_item_type)
+
+        # Parse tags as labels
+        tags_str = fields.get("System.Tags", "")
+        labels = []
+        if tags_str:
+            for tag in tags_str.split(";"):
+                tag = tag.strip()
+                if tag:
+                    labels.append(Label(name=tag))
+
+        # Build URL
+        url = data.get("url", "")
+        if "_apis/wit/workitems" in url:
+            # Convert API URL to web URL
+            web_url = (
+                f"https://dev.azure.com/{self.config.organization}/"
+                f"{self.config.project}/_workitems/edit/{data['id']}"
+            )
+        else:
+            web_url = url
+
+        return Issue(
+            id=self._make_unified_id("issue", str(data["id"])),
+            provider_id=str(data["id"]),
+            title=fields.get("System.Title", ""),
+            body=fields.get("System.Description"),
+            state=state,
+            type=issue_type,
+            url=web_url,
+            created_at=self._parse_datetime(fields.get("System.CreatedDate", "")),
+            updated_at=self._parse_datetime(fields.get("System.ChangedDate", "")),
+            labels=labels,
+        )
+
+    def _parse_pull_request(self, data: dict) -> PullRequest:
+        """Parse Azure DevOps pull request into PullRequest model."""
+        # Parse state
+        status = data.get("status", "active")
+        if status == "completed":
+            state = PRState.MERGED
+        elif status == "abandoned":
+            state = PRState.CLOSED
+        else:
+            state = PRState.OPEN
+
+        # Parse branches
+        source_ref = data.get("sourceRefName", "")
+        target_ref = data.get("targetRefName", "")
+        source_branch = source_ref.replace("refs/heads/", "")
+        target_branch = target_ref.replace("refs/heads/", "")
+
+        # Build URL
+        web_url = (
+            f"https://dev.azure.com/{self.config.organization}/"
+            f"{self.config.project}/_git/pullrequest/{data['pullRequestId']}"
+        )
+
+        merged_at = None
+        if data.get("closedDate") and state == PRState.MERGED:
+            merged_at = self._parse_datetime(data["closedDate"])
+
+        return PullRequest(
+            id=self._make_unified_id("pr", str(data["pullRequestId"])),
+            provider_id=str(data["pullRequestId"]),
+            title=data.get("title", ""),
+            body=data.get("description"),
+            source_branch=source_branch,
+            target_branch=target_branch,
+            state=state,
+            url=web_url,
+            created_at=self._parse_datetime(data.get("creationDate", "")),
+            merged_at=merged_at,
+        )
+
+    def _parse_iteration(self, data: dict) -> Milestone:
+        """Parse Azure DevOps iteration into Milestone model."""
+        attributes = data.get("attributes", {})
+
+        # Determine state based on dates
+        state = MilestoneState.OPEN
+        if attributes.get("finishDate"):
+            finish_date = self._parse_datetime(attributes["finishDate"])
+            if finish_date < datetime.now(finish_date.tzinfo):
+                state = MilestoneState.CLOSED
+
+        due_date = None
+        if attributes.get("finishDate"):
+            due_date = self._parse_datetime(attributes["finishDate"])
+
+        return Milestone(
+            id=self._make_unified_id("ms", str(data["id"])),
+            provider_id=str(data["id"]),
+            title=data.get("name", ""),
+            description=None,  # ADO iterations don't have descriptions
+            state=state,
+            due_date=due_date,
+        )
+
+    def _parse_datetime(self, date_str: str) -> datetime:
+        """Parse Azure DevOps datetime string."""
+        if not date_str:
+            return datetime.now()
+        try:
+            # Handle Azure DevOps datetime format
+            return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.now()

--- a/src/doit_cli/services/providers/base.py
+++ b/src/doit_cli/services/providers/base.py
@@ -1,0 +1,334 @@
+"""Abstract base class for git providers.
+
+This module defines the GitProvider interface that all provider
+implementations must follow.
+"""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Optional
+
+from ...models.provider_models import (
+    Issue,
+    IssueCreateRequest,
+    IssueFilters,
+    IssueUpdateRequest,
+    Milestone,
+    MilestoneCreateRequest,
+    MilestoneState,
+    PullRequest,
+    PRCreateRequest,
+    PRFilters,
+)
+
+
+class ProviderType(Enum):
+    """Supported git provider types."""
+
+    GITHUB = "github"
+    AZURE_DEVOPS = "azure_devops"
+    GITLAB = "gitlab"
+
+
+class GitProvider(ABC):
+    """Abstract interface for git hosting providers.
+
+    All git providers (GitHub, Azure DevOps, GitLab) must implement this interface
+    to be used with the doit CLI.
+
+    Usage:
+        provider = ProviderFactory.create()
+        issue = provider.create_issue(IssueCreateRequest(title="Bug fix"))
+    """
+
+    @property
+    @abstractmethod
+    def provider_type(self) -> ProviderType:
+        """Return the provider type identifier."""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the human-readable provider name."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if the provider is properly configured and available.
+
+        Returns:
+            True if the provider can make API calls, False otherwise.
+        """
+        pass
+
+    # -------------------------------------------------------------------------
+    # Issue Operations
+    # -------------------------------------------------------------------------
+
+    @abstractmethod
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        """Create a new issue.
+
+        Args:
+            request: Issue creation parameters.
+
+        Returns:
+            The created Issue with populated ID and URL.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+            ProviderError: For other provider-specific errors.
+        """
+        pass
+
+    @abstractmethod
+    def get_issue(self, issue_id: str) -> Issue:
+        """Get an issue by its ID.
+
+        Args:
+            issue_id: The issue ID (provider-specific or unified).
+
+        Returns:
+            The Issue object.
+
+        Raises:
+            ResourceNotFoundError: If the issue does not exist.
+            AuthenticationError: If not authenticated.
+        """
+        pass
+
+    @abstractmethod
+    def list_issues(self, filters: Optional[IssueFilters] = None) -> list[Issue]:
+        """List issues matching the given filters.
+
+        Args:
+            filters: Optional filters to apply.
+
+        Returns:
+            List of matching Issue objects.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+        """
+        pass
+
+    @abstractmethod
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        """Update an existing issue.
+
+        Args:
+            issue_id: The issue ID to update.
+            updates: The fields to update.
+
+        Returns:
+            The updated Issue object.
+
+        Raises:
+            ResourceNotFoundError: If the issue does not exist.
+            ValidationError: If update parameters are invalid.
+        """
+        pass
+
+    # -------------------------------------------------------------------------
+    # Pull Request Operations
+    # -------------------------------------------------------------------------
+
+    @abstractmethod
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        """Create a new pull request.
+
+        Args:
+            request: Pull request creation parameters.
+
+        Returns:
+            The created PullRequest with populated ID and URL.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+            ResourceNotFoundError: If source/target branch doesn't exist.
+        """
+        pass
+
+    @abstractmethod
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        """Get a pull request by its ID.
+
+        Args:
+            pr_id: The pull request ID (provider-specific or unified).
+
+        Returns:
+            The PullRequest object.
+
+        Raises:
+            ResourceNotFoundError: If the PR does not exist.
+        """
+        pass
+
+    @abstractmethod
+    def list_pull_requests(
+        self, filters: Optional[PRFilters] = None
+    ) -> list[PullRequest]:
+        """List pull requests matching the given filters.
+
+        Args:
+            filters: Optional filters to apply.
+
+        Returns:
+            List of matching PullRequest objects.
+        """
+        pass
+
+    # -------------------------------------------------------------------------
+    # Milestone Operations
+    # -------------------------------------------------------------------------
+
+    @abstractmethod
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        """Create a new milestone.
+
+        Args:
+            request: Milestone creation parameters.
+
+        Returns:
+            The created Milestone with populated ID.
+
+        Raises:
+            AuthenticationError: If not authenticated.
+            ValidationError: If request parameters are invalid.
+        """
+        pass
+
+    @abstractmethod
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        """Get a milestone by its ID.
+
+        Args:
+            milestone_id: The milestone ID (provider-specific or unified).
+
+        Returns:
+            The Milestone object.
+
+        Raises:
+            ResourceNotFoundError: If the milestone does not exist.
+        """
+        pass
+
+    @abstractmethod
+    def list_milestones(
+        self, state: Optional[MilestoneState] = None
+    ) -> list[Milestone]:
+        """List milestones.
+
+        Args:
+            state: Optional state filter (open/closed).
+
+        Returns:
+            List of Milestone objects.
+        """
+        pass
+
+    # -------------------------------------------------------------------------
+    # Helper Methods (common to all providers)
+    # -------------------------------------------------------------------------
+
+    def _make_unified_id(self, entity_type: str, provider_id: str) -> str:
+        """Create a unified ID from a provider-specific ID.
+
+        Args:
+            entity_type: Type of entity (e.g., "issue", "pr", "ms")
+            provider_id: The provider-specific ID
+
+        Returns:
+            Unified ID in format: {provider}:{entity_type}:{provider_id}
+        """
+        return f"{self.provider_type.value}:{entity_type}:{provider_id}"
+
+    def _extract_provider_id(self, unified_id: str) -> str:
+        """Extract the provider-specific ID from a unified ID.
+
+        Args:
+            unified_id: A unified ID or provider-specific ID
+
+        Returns:
+            The provider-specific ID
+        """
+        if ":" in unified_id:
+            parts = unified_id.split(":")
+            return parts[-1]
+        return unified_id
+
+
+# =============================================================================
+# Rate Limiting Utilities
+# =============================================================================
+
+import time
+from functools import wraps
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def with_retry(
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exponential_base: float = 2.0,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator for retrying operations with exponential backoff.
+
+    Use this decorator on provider methods that may encounter
+    rate limits or transient network errors.
+
+    Args:
+        max_retries: Maximum number of retry attempts.
+        base_delay: Initial delay in seconds.
+        max_delay: Maximum delay in seconds.
+        exponential_base: Base for exponential backoff calculation.
+
+    Returns:
+        Decorated function that retries on RateLimitError.
+
+    Example:
+        @with_retry(max_retries=3)
+        def create_issue(self, request):
+            ...
+    """
+    from .exceptions import RateLimitError
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> T:
+            last_exception = None
+            delay = base_delay
+
+            for attempt in range(max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except RateLimitError as e:
+                    last_exception = e
+
+                    if attempt == max_retries:
+                        raise
+
+                    # Use retry_after if provided, otherwise exponential backoff
+                    if e.retry_after:
+                        wait_time = min(e.retry_after, max_delay)
+                    else:
+                        wait_time = min(delay, max_delay)
+                        delay *= exponential_base
+
+                    time.sleep(wait_time)
+
+            # Should not reach here, but satisfy type checker
+            if last_exception:
+                raise last_exception
+            raise RuntimeError("Unexpected retry loop exit")
+
+        return wrapper
+
+    return decorator

--- a/src/doit_cli/services/providers/exceptions.py
+++ b/src/doit_cli/services/providers/exceptions.py
@@ -1,0 +1,156 @@
+"""Provider exception hierarchy.
+
+This module defines all exceptions that can be raised by git provider operations.
+"""
+
+from typing import Optional
+
+
+class ProviderError(Exception):
+    """Base exception for all provider errors."""
+
+    def __init__(self, message: str, cause: Optional[Exception] = None):
+        super().__init__(message)
+        self.message = message
+        self.cause = cause
+
+    def __str__(self) -> str:
+        if self.cause:
+            return f"{self.message} (caused by: {self.cause})"
+        return self.message
+
+
+class AuthenticationError(ProviderError):
+    """Raised when authentication fails.
+
+    This error indicates that the provider credentials are missing,
+    expired, or invalid.
+    """
+
+    def __init__(
+        self,
+        message: str = "Authentication failed",
+        cause: Optional[Exception] = None,
+        provider: Optional[str] = None,
+    ):
+        super().__init__(message, cause)
+        self.provider = provider
+
+
+class RateLimitError(ProviderError):
+    """Raised when API rate limit is exceeded.
+
+    This error indicates that the provider's API rate limit has been
+    reached. The retry_after attribute indicates when to retry.
+    """
+
+    def __init__(
+        self,
+        message: str = "Rate limit exceeded",
+        retry_after: Optional[int] = None,
+        cause: Optional[Exception] = None,
+    ):
+        super().__init__(message, cause)
+        self.retry_after = retry_after  # Seconds until rate limit resets
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if self.retry_after:
+            return f"{base} (retry after {self.retry_after} seconds)"
+        return base
+
+
+class ResourceNotFoundError(ProviderError):
+    """Raised when a requested resource does not exist.
+
+    This error indicates that the requested issue, PR, milestone,
+    or other resource was not found.
+    """
+
+    def __init__(
+        self,
+        resource_type: str,
+        resource_id: str,
+        cause: Optional[Exception] = None,
+    ):
+        message = f"{resource_type} not found: {resource_id}"
+        super().__init__(message, cause)
+        self.resource_type = resource_type
+        self.resource_id = resource_id
+
+
+class ValidationError(ProviderError):
+    """Raised when request validation fails.
+
+    This error indicates that the request parameters are invalid
+    or don't meet the provider's requirements.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        field: Optional[str] = None,
+        cause: Optional[Exception] = None,
+    ):
+        super().__init__(message, cause)
+        self.field = field
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if self.field:
+            return f"{base} (field: {self.field})"
+        return base
+
+
+class NetworkError(ProviderError):
+    """Raised when a network operation fails.
+
+    This error indicates connectivity issues, timeouts,
+    or other network-related failures.
+    """
+
+    def __init__(
+        self,
+        message: str = "Network error",
+        cause: Optional[Exception] = None,
+        is_timeout: bool = False,
+    ):
+        super().__init__(message, cause)
+        self.is_timeout = is_timeout
+
+
+class ProviderNotConfiguredError(ProviderError):
+    """Raised when no provider is configured.
+
+    This error indicates that the user needs to configure
+    a git provider before using provider features.
+    """
+
+    def __init__(
+        self,
+        message: str = "No git provider configured. Run 'doit provider configure' first.",
+        cause: Optional[Exception] = None,
+    ):
+        super().__init__(message, cause)
+
+
+class ProviderNotImplementedError(ProviderError):
+    """Raised when a provider operation is not implemented.
+
+    This is used for stub implementations (e.g., GitLab)
+    to indicate the operation is not yet available.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        operation: str,
+        cause: Optional[Exception] = None,
+    ):
+        message = (
+            f"{provider} provider does not support '{operation}' yet. "
+            f"See https://github.com/seanbarlow/doit/issues for status."
+        )
+        super().__init__(message, cause)
+        self.provider = provider
+        self.operation = operation

--- a/src/doit_cli/services/providers/github.py
+++ b/src/doit_cli/services/providers/github.py
@@ -1,0 +1,647 @@
+"""GitHub provider implementation using gh CLI.
+
+This module implements the GitProvider interface for GitHub
+using the gh CLI tool for API operations.
+"""
+
+import json
+import subprocess
+from datetime import datetime
+from typing import Optional
+
+from ...models.provider_models import (
+    Issue,
+    IssueCreateRequest,
+    IssueFilters,
+    IssueState,
+    IssueType,
+    IssueUpdateRequest,
+    Label,
+    Milestone,
+    MilestoneCreateRequest,
+    MilestoneState,
+    PullRequest,
+    PRCreateRequest,
+    PRFilters,
+    PRState,
+)
+from .base import GitProvider, ProviderType
+from .exceptions import (
+    AuthenticationError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+
+class GitHubLabelMapper:
+    """Maps labels between unified format and GitHub format."""
+
+    # Issue type to GitHub labels
+    TYPE_TO_LABELS = {
+        IssueType.BUG: ["bug"],
+        IssueType.TASK: ["task"],
+        IssueType.USER_STORY: ["enhancement"],
+        IssueType.FEATURE: ["feature"],
+        IssueType.EPIC: ["epic"],
+    }
+
+    # Reverse mapping
+    LABEL_TO_TYPE = {
+        "bug": IssueType.BUG,
+        "task": IssueType.TASK,
+        "enhancement": IssueType.USER_STORY,
+        "feature": IssueType.FEATURE,
+        "epic": IssueType.EPIC,
+    }
+
+    @classmethod
+    def type_to_labels(cls, issue_type: IssueType) -> list[str]:
+        """Convert issue type to GitHub labels."""
+        return cls.TYPE_TO_LABELS.get(issue_type, [])
+
+    @classmethod
+    def labels_to_type(cls, labels: list[str]) -> IssueType:
+        """Infer issue type from GitHub labels."""
+        for label in labels:
+            label_lower = label.lower()
+            if label_lower in cls.LABEL_TO_TYPE:
+                return cls.LABEL_TO_TYPE[label_lower]
+        return IssueType.TASK  # Default
+
+
+class GitHubProvider(GitProvider):
+    """GitHub implementation using the gh CLI.
+
+    This provider uses the gh CLI tool for all GitHub API operations,
+    which handles authentication automatically.
+    """
+
+    def __init__(self, timeout: int = 30):
+        """Initialize the GitHub provider.
+
+        Args:
+            timeout: Timeout in seconds for gh CLI commands.
+        """
+        self.timeout = timeout
+
+    @property
+    def provider_type(self) -> ProviderType:
+        return ProviderType.GITHUB
+
+    @property
+    def name(self) -> str:
+        return "GitHub"
+
+    @property
+    def is_available(self) -> bool:
+        """Check if gh CLI is installed and authenticated."""
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
+    # -------------------------------------------------------------------------
+    # Issue Operations
+    # -------------------------------------------------------------------------
+
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        """Create a new GitHub issue."""
+        self._ensure_authenticated()
+
+        # Build label list
+        all_labels = list(request.labels)
+        all_labels.extend(GitHubLabelMapper.type_to_labels(request.type))
+
+        cmd = ["gh", "issue", "create", "--title", request.title]
+
+        if request.body:
+            cmd.extend(["--body", request.body])
+
+        if all_labels:
+            cmd.extend(["--label", ",".join(all_labels)])
+
+        if request.milestone_id:
+            cmd.extend(["--milestone", request.milestone_id])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                self._handle_error(result.stderr)
+
+            # Parse created issue URL
+            url = result.stdout.strip()
+            issue_number = url.split("/")[-1]
+
+            # Fetch the created issue to get full details
+            return self.get_issue(issue_number)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """Get a GitHub issue by number."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        try:
+            result = subprocess.run(
+                [
+                    "gh", "issue", "view", provider_id,
+                    "--json", "number,title,body,state,url,createdAt,updatedAt,labels,milestone"
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                if "not found" in result.stderr.lower():
+                    raise ResourceNotFoundError("Issue", provider_id)
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return self._parse_issue(data)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    def list_issues(self, filters: Optional[IssueFilters] = None) -> list[Issue]:
+        """List GitHub issues matching filters."""
+        self._ensure_authenticated()
+
+        cmd = [
+            "gh", "issue", "list",
+            "--json", "number,title,body,state,url,createdAt,updatedAt,labels,milestone"
+        ]
+
+        if filters:
+            if filters.state:
+                state_map = {
+                    IssueState.OPEN: "open",
+                    IssueState.CLOSED: "closed",
+                }
+                cmd.extend(["--state", state_map.get(filters.state, "open")])
+
+            if filters.labels:
+                for label in filters.labels:
+                    cmd.extend(["--label", label])
+
+            if filters.limit:
+                cmd.extend(["--limit", str(filters.limit)])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return [self._parse_issue(item) for item in data]
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        """Update a GitHub issue."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        cmd = ["gh", "issue", "edit", provider_id]
+
+        if updates.title:
+            cmd.extend(["--title", updates.title])
+
+        if updates.body:
+            cmd.extend(["--body", updates.body])
+
+        if updates.labels is not None:
+            for label in updates.labels:
+                cmd.extend(["--add-label", label])
+
+        try:
+            if len(cmd) > 3:  # Only run if there are updates
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout,
+                )
+
+                if result.returncode != 0:
+                    self._handle_error(result.stderr)
+
+            # Handle state change separately
+            if updates.state == IssueState.CLOSED:
+                subprocess.run(
+                    ["gh", "issue", "close", provider_id],
+                    capture_output=True,
+                    timeout=self.timeout,
+                )
+            elif updates.state == IssueState.OPEN:
+                subprocess.run(
+                    ["gh", "issue", "reopen", provider_id],
+                    capture_output=True,
+                    timeout=self.timeout,
+                )
+
+            return self.get_issue(provider_id)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+
+    # -------------------------------------------------------------------------
+    # Pull Request Operations
+    # -------------------------------------------------------------------------
+
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        """Create a new GitHub pull request."""
+        self._ensure_authenticated()
+
+        cmd = [
+            "gh", "pr", "create",
+            "--title", request.title,
+            "--head", request.source_branch,
+            "--base", request.target_branch,
+        ]
+
+        if request.body:
+            cmd.extend(["--body", request.body])
+
+        if request.labels:
+            cmd.extend(["--label", ",".join(request.labels)])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                self._handle_error(result.stderr)
+
+            # Parse created PR URL
+            url = result.stdout.strip()
+            pr_number = url.split("/")[-1]
+
+            return self.get_pull_request(pr_number)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        """Get a GitHub pull request by number."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(pr_id)
+
+        try:
+            result = subprocess.run(
+                [
+                    "gh", "pr", "view", provider_id,
+                    "--json", "number,title,body,state,url,createdAt,mergedAt,headRefName,baseRefName,labels"
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                if "not found" in result.stderr.lower():
+                    raise ResourceNotFoundError("Pull Request", provider_id)
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return self._parse_pull_request(data)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    def list_pull_requests(
+        self, filters: Optional[PRFilters] = None
+    ) -> list[PullRequest]:
+        """List GitHub pull requests matching filters."""
+        self._ensure_authenticated()
+
+        cmd = [
+            "gh", "pr", "list",
+            "--json", "number,title,body,state,url,createdAt,mergedAt,headRefName,baseRefName,labels"
+        ]
+
+        if filters:
+            if filters.state:
+                state_map = {
+                    PRState.OPEN: "open",
+                    PRState.MERGED: "merged",
+                    PRState.CLOSED: "closed",
+                }
+                cmd.extend(["--state", state_map.get(filters.state, "open")])
+
+            if filters.source_branch:
+                cmd.extend(["--head", filters.source_branch])
+
+            if filters.target_branch:
+                cmd.extend(["--base", filters.target_branch])
+
+            if filters.limit:
+                cmd.extend(["--limit", str(filters.limit)])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return [self._parse_pull_request(item) for item in data]
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    # -------------------------------------------------------------------------
+    # Milestone Operations
+    # -------------------------------------------------------------------------
+
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        """Create a new GitHub milestone."""
+        self._ensure_authenticated()
+        repo_slug = self._get_repo_slug()
+
+        cmd = [
+            "gh", "api",
+            f"repos/{repo_slug}/milestones",
+            "--method", "POST",
+            "--field", f"title={request.title}",
+            "--field", "state=open",
+        ]
+
+        if request.description:
+            cmd.extend(["--field", f"description={request.description}"])
+
+        if request.due_date:
+            cmd.extend(["--field", f"due_on={request.due_date.isoformat()}"])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                if "422" in result.stderr:
+                    raise ValidationError(f"Milestone '{request.title}' already exists")
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return self._parse_milestone(data)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        """Get a GitHub milestone by number."""
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(milestone_id)
+        repo_slug = self._get_repo_slug()
+
+        try:
+            result = subprocess.run(
+                ["gh", "api", f"repos/{repo_slug}/milestones/{provider_id}"],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                if "404" in result.stderr:
+                    raise ResourceNotFoundError("Milestone", provider_id)
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+            return self._parse_milestone(data)
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    def list_milestones(
+        self, state: Optional[MilestoneState] = None
+    ) -> list[Milestone]:
+        """List GitHub milestones."""
+        self._ensure_authenticated()
+        repo_slug = self._get_repo_slug()
+
+        try:
+            result = subprocess.run(
+                ["gh", "api", f"repos/{repo_slug}/milestones"],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                self._handle_error(result.stderr)
+
+            data = json.loads(result.stdout)
+
+            # Filter by state if requested
+            if state:
+                state_str = "open" if state == MilestoneState.OPEN else "closed"
+                data = [m for m in data if m.get("state") == state_str]
+
+            return [self._parse_milestone(item) for item in data]
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+        except json.JSONDecodeError as e:
+            raise ProviderError(f"Failed to parse GitHub response: {e}")
+
+    # -------------------------------------------------------------------------
+    # Helper Methods
+    # -------------------------------------------------------------------------
+
+    def _ensure_authenticated(self) -> None:
+        """Verify gh CLI is available and authenticated."""
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                raise AuthenticationError(
+                    "GitHub CLI not authenticated. Run: gh auth login",
+                    provider="GitHub",
+                )
+        except FileNotFoundError:
+            raise AuthenticationError(
+                "GitHub CLI (gh) not installed. Install from: https://cli.github.com",
+                provider="GitHub",
+            )
+
+    def _handle_error(self, stderr: str) -> None:
+        """Convert gh CLI error to appropriate exception."""
+        stderr_lower = stderr.lower()
+
+        if "rate limit" in stderr_lower:
+            raise RateLimitError("GitHub API rate limit exceeded")
+        elif "not found" in stderr_lower or "404" in stderr:
+            raise ResourceNotFoundError("Resource", "unknown")
+        elif "unauthorized" in stderr_lower or "401" in stderr:
+            raise AuthenticationError("GitHub authentication failed", provider="GitHub")
+        elif "validation" in stderr_lower or "422" in stderr:
+            raise ValidationError(f"GitHub validation error: {stderr}")
+        else:
+            raise ProviderError(f"GitHub error: {stderr}")
+
+    def _get_repo_slug(self) -> str:
+        """Get the repository slug (owner/repo) from git remote."""
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+            if result.returncode != 0:
+                raise ProviderError("Not in a git repository")
+
+            remote_url = result.stdout.strip()
+
+            # Parse GitHub URL
+            if remote_url.startswith("git@github.com:"):
+                slug = remote_url.replace("git@github.com:", "").replace(".git", "")
+            elif "github.com/" in remote_url:
+                slug = remote_url.split("github.com/")[1].replace(".git", "")
+            else:
+                raise ProviderError("Not a GitHub repository")
+
+            return slug
+
+        except subprocess.TimeoutExpired:
+            raise NetworkError("Git command timeout", is_timeout=True)
+
+    def _parse_issue(self, data: dict) -> Issue:
+        """Parse gh CLI JSON output into Issue model."""
+        labels = [Label(name=l["name"]) for l in data.get("labels", [])]
+        label_names = [l["name"] for l in data.get("labels", [])]
+
+        state = IssueState.OPEN if data.get("state", "").upper() == "OPEN" else IssueState.CLOSED
+
+        milestone_id = None
+        if data.get("milestone"):
+            milestone_id = str(data["milestone"].get("number", ""))
+
+        return Issue(
+            id=self._make_unified_id("issue", str(data["number"])),
+            provider_id=str(data["number"]),
+            title=data["title"],
+            body=data.get("body"),
+            state=state,
+            type=GitHubLabelMapper.labels_to_type(label_names),
+            url=data["url"],
+            created_at=self._parse_datetime(data.get("createdAt", "")),
+            updated_at=self._parse_datetime(data.get("updatedAt", "")),
+            labels=labels,
+            milestone_id=milestone_id,
+        )
+
+    def _parse_pull_request(self, data: dict) -> PullRequest:
+        """Parse gh CLI JSON output into PullRequest model."""
+        labels = [Label(name=l["name"]) for l in data.get("labels", [])]
+
+        state_str = data.get("state", "").upper()
+        if state_str == "MERGED":
+            state = PRState.MERGED
+        elif state_str == "CLOSED":
+            state = PRState.CLOSED
+        else:
+            state = PRState.OPEN
+
+        merged_at = None
+        if data.get("mergedAt"):
+            merged_at = self._parse_datetime(data["mergedAt"])
+
+        return PullRequest(
+            id=self._make_unified_id("pr", str(data["number"])),
+            provider_id=str(data["number"]),
+            title=data["title"],
+            body=data.get("body"),
+            source_branch=data.get("headRefName", ""),
+            target_branch=data.get("baseRefName", ""),
+            state=state,
+            url=data["url"],
+            created_at=self._parse_datetime(data.get("createdAt", "")),
+            labels=labels,
+            merged_at=merged_at,
+        )
+
+    def _parse_milestone(self, data: dict) -> Milestone:
+        """Parse gh API JSON output into Milestone model."""
+        state = MilestoneState.OPEN if data.get("state") == "open" else MilestoneState.CLOSED
+
+        due_date = None
+        if data.get("due_on"):
+            due_date = self._parse_datetime(data["due_on"])
+
+        return Milestone(
+            id=self._make_unified_id("ms", str(data["number"])),
+            provider_id=str(data["number"]),
+            title=data["title"],
+            description=data.get("description"),
+            state=state,
+            due_date=due_date,
+            issue_count=data.get("open_issues", 0) + data.get("closed_issues", 0),
+            closed_issue_count=data.get("closed_issues", 0),
+            url=data.get("html_url"),
+        )
+
+    def _parse_datetime(self, date_str: str) -> datetime:
+        """Parse ISO datetime string."""
+        if not date_str:
+            return datetime.now()
+        try:
+            # Handle GitHub's datetime format
+            return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.now()

--- a/src/doit_cli/services/providers/gitlab.py
+++ b/src/doit_cli/services/providers/gitlab.py
@@ -1,0 +1,112 @@
+"""GitLab provider stub implementation.
+
+This module provides a stub implementation of the GitProvider interface
+for GitLab. Full implementation is planned for a future release.
+"""
+
+from typing import Optional
+
+from ...models.provider_models import (
+    Issue,
+    IssueCreateRequest,
+    IssueFilters,
+    IssueUpdateRequest,
+    Milestone,
+    MilestoneCreateRequest,
+    MilestoneState,
+    PullRequest,
+    PRCreateRequest,
+    PRFilters,
+)
+from .base import GitProvider, ProviderType
+from .exceptions import ProviderNotImplementedError
+
+
+class GitLabProvider(GitProvider):
+    """GitLab stub implementation.
+
+    This provider is a placeholder for future GitLab support.
+    All operations currently raise ProviderNotImplementedError with
+    guidance on the feature's development status.
+
+    Note:
+        GitLab support is planned for a future release.
+        See https://github.com/seanbarlow/doit/issues for status.
+    """
+
+    def __init__(self, timeout: int = 30):
+        """Initialize the GitLab provider.
+
+        Args:
+            timeout: Timeout in seconds for API requests (unused in stub).
+        """
+        self.timeout = timeout
+
+    @property
+    def provider_type(self) -> ProviderType:
+        return ProviderType.GITLAB
+
+    @property
+    def name(self) -> str:
+        return "GitLab"
+
+    @property
+    def is_available(self) -> bool:
+        """GitLab is not yet available."""
+        return False
+
+    # -------------------------------------------------------------------------
+    # Issue Operations
+    # -------------------------------------------------------------------------
+
+    def create_issue(self, request: IssueCreateRequest) -> Issue:
+        """Create a new GitLab issue (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "create_issue")
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """Get a GitLab issue by ID (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "get_issue")
+
+    def list_issues(self, filters: Optional[IssueFilters] = None) -> list[Issue]:
+        """List GitLab issues (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "list_issues")
+
+    def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
+        """Update a GitLab issue (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "update_issue")
+
+    # -------------------------------------------------------------------------
+    # Pull Request Operations (Merge Requests in GitLab)
+    # -------------------------------------------------------------------------
+
+    def create_pull_request(self, request: PRCreateRequest) -> PullRequest:
+        """Create a new GitLab merge request (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "create_merge_request")
+
+    def get_pull_request(self, pr_id: str) -> PullRequest:
+        """Get a GitLab merge request by ID (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "get_merge_request")
+
+    def list_pull_requests(
+        self, filters: Optional[PRFilters] = None
+    ) -> list[PullRequest]:
+        """List GitLab merge requests (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "list_merge_requests")
+
+    # -------------------------------------------------------------------------
+    # Milestone Operations
+    # -------------------------------------------------------------------------
+
+    def create_milestone(self, request: MilestoneCreateRequest) -> Milestone:
+        """Create a new GitLab milestone (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "create_milestone")
+
+    def get_milestone(self, milestone_id: str) -> Milestone:
+        """Get a GitLab milestone by ID (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "get_milestone")
+
+    def list_milestones(
+        self, state: Optional[MilestoneState] = None
+    ) -> list[Milestone]:
+        """List GitLab milestones (not implemented)."""
+        raise ProviderNotImplementedError("GitLab", "list_milestones")


### PR DESCRIPTION
## Summary

Implements a unified interface for git providers (GitHub, Azure DevOps, GitLab) enabling the doit CLI to work with multiple hosting providers through a single consistent interface.

## Changes

- **Provider Interface**: GitProvider abstract base class with operations for issues, PRs, and milestones
- **GitHub Provider**: Full implementation using gh CLI
- **Azure DevOps Provider**: Full implementation using REST API with httpx
- **GitLab Provider**: Stub implementation for future extension
- **Provider Factory**: Auto-detection from git remote URL
- **CLI Commands**: `doit provider configure`, `status`, `detect`
- **Cross-cutting**: Rate limiting with exponential backoff, offline mode graceful degradation

## Files Created (15 new files)

| File | Purpose |
|------|---------|
| `src/doit_cli/services/providers/base.py` | GitProvider ABC + retry decorator |
| `src/doit_cli/services/providers/github.py` | GitHub implementation |
| `src/doit_cli/services/providers/azure_devops.py` | Azure DevOps implementation |
| `src/doit_cli/services/providers/gitlab.py` | GitLab stub |
| `src/doit_cli/services/provider_factory.py` | Factory + auto-detection |
| `src/doit_cli/services/provider_config.py` | YAML config management |
| `src/doit_cli/models/provider_models.py` | Unified data models |
| `src/doit_cli/cli/provider_command.py` | CLI commands |
| `docs/features/044-git-provider-abstraction.md` | Feature documentation |

## Testing

- [ ] Automated tests pass
- [x] Manual testing complete
- [ ] Code review approved

## Requirements

| ID | Description | Status |
|----|-------------|--------|
| FR-001 | Unified provider interface | Done |
| FR-002 | Support GitHub, Azure DevOps, GitLab | Done |
| FR-003 | Auto-detect provider from git remote | Done |
| FR-004 | Allow explicit provider override | Done |
| FR-005 | Store config in `.doit/config/provider.yaml` | Done |
| FR-019 | Rate limit handling | Done |
| FR-021 | Offline mode graceful degradation | Done |

## Related Issues

No GitHub issues were created for this feature.

---
Generated by `/doit.checkin`