### PR TITLE
refactor(errors): DoitError hierarchy and chained raises (Phase 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ ignore = [
     "E402",    # module-import-not-at-top — Typer command modules use deferred imports
     "E741",    # ambiguous names (l, I, O) — small number of historical uses
     "B008",    # function call as default arg — Typer's Option/Argument use this pattern
-    "B904",    # raise-without-from — addressed in Phase 2 (error handling)
     "PTH",     # os.path → pathlib — addressed in Phase 3 (service refactor)
     "SIM102",  # collapsible-if — case-by-case readability call
     "SIM105",  # suppressible-exception — wholesale contextlib.suppress can hide intent

--- a/src/doit_cli/__init__.py
+++ b/src/doit_cli/__init__.py
@@ -427,7 +427,7 @@ def select_with_arrows(
 
                 except KeyboardInterrupt:
                     console.print("\n[yellow]Selection cancelled[/yellow]")
-                    raise typer.Exit(1)
+                    raise typer.Exit(1) from None
 
     run_selection_loop()
 
@@ -703,11 +703,11 @@ def download_template_from_github(
         except ValueError as je:
             raise RuntimeError(
                 f"Failed to parse release JSON: {je}\nRaw (truncated 400): {response.text[:400]}"
-            )
+            ) from je
     except Exception as e:
         console.print("[red]Error fetching release information[/red]")
         console.print(Panel(str(e), title="Fetch Error", border_style="red"))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     assets = release_data.get("assets", [])
     pattern = f"doit-template-{ai_assistant}-{script_type}"
@@ -790,7 +790,7 @@ def download_template_from_github(
         if zip_path.exists():
             zip_path.unlink()
         console.print(Panel(detail, title="Download Error", border_style="red"))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
     if verbose:
         console.print(f"Downloaded: {filename}")
     metadata = {
@@ -956,7 +956,7 @@ def download_and_extract_template(
 
         if not is_current_dir and project_path.exists():
             shutil.rmtree(project_path)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
     else:
         if tracker:
             tracker.complete("extract")
@@ -991,7 +991,7 @@ def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = 
                 with script.open("rb") as f:
                     if f.read(2) != b"#!":
                         continue
-            except Exception:
+            except OSError:
                 continue
             st = script.stat()
             mode = st.st_mode
@@ -1290,7 +1290,7 @@ def init(
                 )
             if not here and project_path.exists():
                 shutil.rmtree(project_path)
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
         finally:
             pass
 
@@ -1423,7 +1423,7 @@ def version():
     cli_version = "unknown"
     try:
         cli_version = importlib.metadata.version("doit-cli")
-    except Exception:
+    except importlib.metadata.PackageNotFoundError:
         # Fallback: try reading from pyproject.toml if running from source
         try:
             import tomllib
@@ -1433,7 +1433,7 @@ def version():
                 with open(pyproject_path, "rb") as f:
                     data = tomllib.load(f)
                     cli_version = data.get("project", {}).get("version", "unknown")
-        except Exception:
+        except (OSError, tomllib.TOMLDecodeError):
             pass
 
     # Fetch latest template release version
@@ -1463,9 +1463,9 @@ def version():
                 try:
                     dt = datetime.fromisoformat(release_date.replace("Z", "+00:00"))
                     release_date = dt.strftime("%Y-%m-%d")
-                except Exception:
+                except ValueError:
                     pass
-    except Exception:
+    except httpx.HTTPError:
         pass
 
     info_table = Table(show_header=False, box=None, padding=(0, 2))

--- a/src/doit_cli/cli/analytics_command.py
+++ b/src/doit_cli/cli/analytics_command.py
@@ -86,7 +86,7 @@ def show(
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 def _print_completion_summary(summary: dict) -> None:
@@ -163,7 +163,7 @@ def cycles(
                 filter_days = None  # since overrides days
             except ValueError:
                 console.print(f"[red]Error:[/red] Invalid date format '{since}'. Use YYYY-MM-DD.")
-                raise typer.Exit(code=2)
+                raise typer.Exit(code=2) from None
 
         stats, records = service.get_cycle_time_stats(days=filter_days, since=since_date)
 
@@ -186,7 +186,7 @@ def cycles(
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 def _print_cycles_json(stats, records) -> None:
@@ -306,7 +306,7 @@ def velocity(
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 def _print_velocity_json(velocity_data) -> None:
@@ -411,7 +411,7 @@ def spec(
                     console.print("\nAvailable specs:")
                     for a in available[:5]:
                         console.print(f"  - {a}")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from None
 
         if json_output:
             _print_spec_json(metadata)
@@ -425,7 +425,7 @@ def spec(
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 def _print_spec_json(metadata) -> None:
@@ -548,10 +548,10 @@ def export(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
     except OSError as e:
         console.print(f"[red]Error:[/red] Failed to export report: {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 def _generate_markdown_report(report) -> str:

--- a/src/doit_cli/cli/context_command.py
+++ b/src/doit_cli/cli/context_command.py
@@ -73,7 +73,7 @@ def show_context(
         context = loader.load()
     except Exception as e:
         console.print(f"\n[red]Error loading context: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     # Show command-specific info
     if command:

--- a/src/doit_cli/cli/fixit_command.py
+++ b/src/doit_cli/cli/fixit_command.py
@@ -63,7 +63,7 @@ def start(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     # Check GitHub availability
     if not service.is_github_available():
@@ -104,7 +104,7 @@ def start(
 
     except FixitServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 @app.command("list")
@@ -126,7 +126,7 @@ def list_bugs(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     bugs = service.list_bugs(label=label, limit=limit)
 
@@ -173,7 +173,7 @@ def status(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     if issue_id is None:
         # Show active workflow
@@ -212,7 +212,7 @@ def cancel(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     if issue_id is None:
         workflow = service.get_active_workflow()
@@ -249,7 +249,7 @@ def list_workflows() -> None:
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     workflows = service.list_workflows()
 
@@ -312,7 +312,7 @@ def investigate(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     # Get issue_id from active workflow if not provided
     if issue_id is None:
@@ -353,7 +353,7 @@ def investigate(
             ft = FindingType(finding_type)
         except ValueError:
             console.print(f"[red]Invalid finding type: {finding_type}[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from None
 
         finding = service.add_finding(
             issue_id=issue_id,
@@ -427,7 +427,7 @@ def plan(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     # Get issue_id from active workflow if not provided
     if issue_id is None:
@@ -500,7 +500,7 @@ def review(
         service = FixitService()
     except GitHubServiceError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
     # Get issue_id from active workflow if not provided
     if issue_id is None:

--- a/src/doit_cli/cli/hooks_command.py
+++ b/src/doit_cli/cli/hooks_command.py
@@ -57,7 +57,7 @@ def install_hooks(
 
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @hooks_app.command("uninstall")
@@ -149,7 +149,7 @@ def restore_hooks(
 
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @hooks_app.command("validate")

--- a/src/doit_cli/cli/init_command.py
+++ b/src/doit_cli/cli/init_command.py
@@ -548,7 +548,7 @@ def init_command(
             agents = parse_agent_string(agent)
         except typer.BadParameter as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
 
     # Non-interactive mode: bypass workflow entirely (FR-003, FR-008)
     if yes:
@@ -592,7 +592,7 @@ def init_command(
         responses = engine.run(workflow, initial_responses=initial_responses)
     except KeyboardInterrupt:
         # State is saved by workflow engine (FR-007)
-        raise typer.Exit(130)
+        raise typer.Exit(130) from None
 
     # Map workflow responses to init parameters (FR-006)
     workflow_agents, template_source = map_workflow_responses(responses)

--- a/src/doit_cli/cli/mcp_command.py
+++ b/src/doit_cli/cli/mcp_command.py
@@ -44,7 +44,7 @@ def serve_command() -> None:
     except ImportError as e:
         console.print(f"[red]Failed to import MCP dependencies: {e}[/red]")
         console.print("Install with: pip install doit-toolkit-cli[mcp]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except Exception as e:
         console.print(f"[red]MCP server error: {e}[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e

--- a/src/doit_cli/cli/memory_command.py
+++ b/src/doit_cli/cli/memory_command.py
@@ -111,7 +111,7 @@ def search_command(
             f"[red]Error:[/red] Invalid query type '{query_type}'. "
             "Use: keyword, phrase, natural, regex"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     # If regex flag is set, override query type
     if use_regex:
@@ -124,7 +124,7 @@ def search_command(
         console.print(
             f"[red]Error:[/red] Invalid source filter '{source}'. Use: all, governance, specs"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     # Validate max results
     if not 1 <= max_results <= 100:
@@ -146,7 +146,7 @@ def search_command(
         )
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(3)
+        raise typer.Exit(3) from e
 
     execution_time_ms = int((time.time() - start_time) * 1000)
 

--- a/src/doit_cli/cli/provider_command.py
+++ b/src/doit_cli/cli/provider_command.py
@@ -79,7 +79,7 @@ def configure_command(
         except ValueError:
             console.print(f"[red]Error: Unknown provider '{provider}'[/red]")
             console.print("Valid providers: github, azure_devops, gitlab")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from None
 
     elif auto_detect or not provider:
         # Auto-detect from git remote
@@ -270,9 +270,9 @@ def wizard_command(
     except WizardCancelledError:
         wizard.handle_cancellation()
         console.print("\n[yellow]Wizard cancelled.[/yellow]")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=0) from None
 
     except KeyboardInterrupt:
         wizard.handle_cancellation()
         console.print("\n[yellow]Wizard interrupted.[/yellow]")
-        raise typer.Exit(code=130)
+        raise typer.Exit(code=130) from None

--- a/src/doit_cli/cli/roadmapit_impl.py
+++ b/src/doit_cli/cli/roadmapit_impl.py
@@ -87,7 +87,7 @@ def show(
 
     except Exception as e:
         console.print(f"[red]✗ Error: {e}[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 def _fetch_github_epics(refresh: bool):
@@ -438,12 +438,12 @@ def add(
                     )
                     console.print(f"  Title: {item}")
                     console.print(f"  Labels: epic, priority:{priority}")
-                    raise typer.Exit(code=1)
+                    raise typer.Exit(code=1) from e
 
                 except GitHubAPIError as e:
                     console.print(f"\n[yellow]⚠ GitHub API error: {e}[/yellow]")
                     console.print("[yellow]  Item not created on GitHub[/yellow]")
-                    raise typer.Exit(code=1)
+                    raise typer.Exit(code=1) from e
 
             else:
                 console.print(
@@ -460,7 +460,7 @@ def add(
 
     except Exception as e:
         console.print(f"[red]✗ Error: {e}[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 @app.command(name="sync-milestones")
@@ -527,16 +527,16 @@ def sync_milestones(
     except GitHubAuthError as e:
         console.print(f"\n[red]✗ GitHub Authentication Error:[/red] {e}")
         console.print("\n[dim]Run: gh auth login[/dim]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except GitHubAPIError as e:
         console.print(f"\n[red]✗ GitHub API Error:[/red] {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except FileNotFoundError as e:
         console.print(f"\n[red]✗ File Not Found:[/red] {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except Exception as e:
         console.print(f"\n[red]✗ Error:[/red] {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 if __name__ == "__main__":

--- a/src/doit_cli/cli/status_command.py
+++ b/src/doit_cli/cli/status_command.py
@@ -109,4 +109,4 @@ def status_command(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e

--- a/src/doit_cli/cli/sync_prompts_command.py
+++ b/src/doit_cli/cli/sync_prompts_command.py
@@ -278,7 +278,7 @@ def sync_prompts_command(
         target_agents = parse_sync_agents(agent)
     except typer.BadParameter as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     # Initialize services
     reader = TemplateReader(project_root=project_root)

--- a/src/doit_cli/cli/team_command.py
+++ b/src/doit_cli/cli/team_command.py
@@ -138,7 +138,7 @@ def init_team(
         if e.errors:
             for error in e.errors:
                 console.print(f"  • {error}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 # =============================================================================
@@ -215,13 +215,13 @@ def add_member(
 
     except MemberAlreadyExistsError:
         console.print(f"[red]Error:[/red] Member already exists: {email}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from None
     except TeamConfigValidationError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except PermissionDeniedError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=3)
+        raise typer.Exit(code=3) from e
 
 
 @app.command("remove")
@@ -265,10 +265,10 @@ def remove_member(
 
     except TeamConfigValidationError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
     except PermissionDeniedError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=3)
+        raise typer.Exit(code=3) from e
 
 
 # =============================================================================
@@ -431,11 +431,11 @@ def sync_memory(
     except NoRemoteError as e:
         console.print(f"[red]Error:[/red] {e}")
         console.print("Push your repository to a remote first.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     except NetworkError as e:
         console.print(f"[yellow]Warning:[/yellow] {e}")
         console.print("Changes saved locally. They will sync when connectivity returns.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 # =============================================================================
@@ -610,7 +610,7 @@ def list_notifications(
             console.print(
                 "Valid types: memory_changed, conflict_detected, member_joined, permission_changed"
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from None
 
     notifications = notif_service.get_notifications(
         unread_only=not all_notifications,
@@ -1108,7 +1108,7 @@ def resolve_conflict(
 
     except ConflictNotFoundError:
         console.print(f"[red]Error:[/red] Conflict not found: {conflict_id}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
 
 @conflict_app.command("clear")

--- a/src/doit_cli/cli/update_command.py
+++ b/src/doit_cli/cli/update_command.py
@@ -47,7 +47,7 @@ def update_command(
             agents = parse_agent_string(agent)
         except typer.BadParameter as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
 
     result = run_init(
         path=path,

--- a/src/doit_cli/cli/validate_command.py
+++ b/src/doit_cli/cli/validate_command.py
@@ -171,11 +171,11 @@ def validate_command(
             print(f'{{"error": "{e}"}}')
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     except ValueError as e:
         if json_output:
             print(f'{{"error": "{e}"}}')
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e

--- a/src/doit_cli/cli/verify_command.py
+++ b/src/doit_cli/cli/verify_command.py
@@ -172,7 +172,7 @@ def verify_command(
                 console.print(json.dumps({"error": str(e)}))
             else:
                 console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
 
     # Create project and validator
     project = Project(path=path.resolve())

--- a/src/doit_cli/cli/xref_command.py
+++ b/src/doit_cli/cli/xref_command.py
@@ -200,7 +200,7 @@ def coverage_command(
             report = service.get_coverage(spec_name=spec_name)
         except FileNotFoundError as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=2) from e
 
         # Format output
         if output_format == "json":
@@ -235,7 +235,7 @@ def coverage_command(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 @xref_app.command(name="locate")
@@ -280,7 +280,7 @@ def locate_command(
             req = service.locate_requirement(requirement_id, spec_name=spec_name)
         except (FileNotFoundError, ValueError) as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=2) from e
 
         if req is None:
             console.print(f"[yellow]Requirement {requirement_id} not found in spec.[/yellow]")
@@ -307,7 +307,7 @@ def locate_command(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 @xref_app.command(name="tasks")
@@ -350,7 +350,7 @@ def tasks_command(
             tasks = service.get_tasks_for_requirement(requirement_id, spec_name=spec_name)
         except (FileNotFoundError, ValueError) as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=2) from e
 
         if not tasks:
             console.print(f"[yellow]No tasks found implementing {requirement_id}[/yellow]")
@@ -415,7 +415,7 @@ def tasks_command(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e
 
 
 @xref_app.command(name="validate")
@@ -464,7 +464,7 @@ def validate_command(
             report = service.get_coverage(spec_name=spec_name)
         except FileNotFoundError as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=2) from e
 
         # Count issues
         error_count = len(orphaned)  # Orphaned references are always errors
@@ -536,4 +536,4 @@ def validate_command(
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=2) from e

--- a/src/doit_cli/errors.py
+++ b/src/doit_cli/errors.py
@@ -1,0 +1,63 @@
+"""Shared error hierarchy for the doit CLI.
+
+Every error raised at a domain boundary should subclass one of the types
+below so callers can catch by category rather than the bare `Exception`.
+Legacy module-local hierarchies (TeamError, WorkflowError, GitHubServiceError)
+are being re-parented to these categories as each service is modernized.
+"""
+
+from __future__ import annotations
+
+
+class DoitError(Exception):
+    """Base class for all doit-originated errors.
+
+    Catch this at the CLI entry point to turn any unexpected failure into a
+    user-facing Rich message with a non-zero exit code. Internal code should
+    raise a more specific subclass.
+    """
+
+
+class DoitConfigError(DoitError):
+    """Configuration is missing, malformed, or inconsistent.
+
+    Raised by loaders that parse YAML/JSON/TOML in `.doit/config/`,
+    constitution files, team configs, or project-level settings.
+    """
+
+
+class DoitStateError(DoitError):
+    """Persisted workflow state is corrupt, stale, or from an incompatible version.
+
+    Raised when reading/writing `.doit/state/` files. A `DoitStateError` implies
+    the user's state directory needs repair or reset — never a recoverable
+    condition.
+    """
+
+
+class DoitTemplateError(DoitError):
+    """A bundled template or rendered command output is invalid.
+
+    Raised by template readers, skill validators, and the sync/prompt
+    generators. Typically indicates a packaging bug rather than user error.
+    """
+
+
+class DoitProviderError(DoitError):
+    """A remote provider (GitHub, GitLab, Azure DevOps) failed a request.
+
+    Wraps `subprocess.CalledProcessError`, `httpx.HTTPError`, and provider-
+    specific CLI errors. Subclass for auth- vs API- vs rate-limit distinctions.
+    """
+
+
+class DoitAuthError(DoitProviderError):
+    """Authentication with a remote provider failed or is missing."""
+
+
+class DoitValidationError(DoitError):
+    """User-supplied input failed validation.
+
+    Raised when CLI arguments, interactive prompts, or file contents violate
+    a documented contract. Always carry a message fit to show the user.
+    """

--- a/src/doit_cli/services/backup_service.py
+++ b/src/doit_cli/services/backup_service.py
@@ -178,8 +178,8 @@ class BackupService:
             try:
                 shutil.rmtree(old_backup)
                 removed.append(old_backup)
-            except Exception:
-                # Silently skip backups that can't be removed
+            except OSError:
+                # Skip backups that can't be removed (permission/missing)
                 pass
 
         return removed

--- a/src/doit_cli/services/conflict_service.py
+++ b/src/doit_cli/services/conflict_service.py
@@ -173,8 +173,8 @@ class ConflictService:
                 )
                 conflicts.append(conflict)
 
-            except Exception:
-                # If we can't read the conflict, skip it
+            except (OSError, UnicodeDecodeError):
+                # If we can't read the conflict file, skip it
                 continue
 
         # Store conflicts in state
@@ -306,7 +306,7 @@ class ConflictService:
             self._archive_conflict(conflict)
 
         except Exception as e:
-            raise ConflictError(f"Failed to resolve conflict: {e}")
+            raise ConflictError(f"Failed to resolve conflict: {e}") from e
 
         return conflict
 

--- a/src/doit_cli/services/context_loader.py
+++ b/src/doit_cli/services/context_loader.py
@@ -79,8 +79,8 @@ def estimate_tokens(text: str) -> int:
             if _tiktoken_encoding is None:
                 _tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
             return len(_tiktoken_encoding.encode(text))
-        except Exception:
-            pass
+        except (ImportError, ValueError, KeyError) as exc:
+            logger.debug("tiktoken estimate failed, falling back: %s", exc)
 
     # Fallback: approximately 4 characters per token
     return max(1, len(text) // 4)
@@ -342,8 +342,8 @@ def compute_similarity_scores(current_text: str, candidate_texts: list[str]) -> 
             # Compute cosine similarity between first text and all others
             similarities = cosine_similarity(tfidf_matrix[0:1], tfidf_matrix[1:])
             return similarities[0].tolist()
-        except Exception:
-            pass
+        except (ValueError, ImportError) as exc:
+            logger.debug("sklearn similarity failed, falling back: %s", exc)
 
     # Fallback: keyword overlap (Jaccard similarity)
     current_keywords = extract_keywords(current_text)
@@ -531,20 +531,17 @@ def parse_completed_roadmap(content: str) -> list[CompletedItem]:
                 # Parse date if provided
                 completion_date = None
                 if date_str:
-                    try:
-                        # Try common formats
-                        for _fmt in ["%Y-%m-%d", "%m/%d/%Y", "%d-%m-%Y"]:
-                            try:
-                                completion_date = (
-                                    date_type.fromisoformat(date_str)
-                                    if "-" in date_str and len(date_str) == 10
-                                    else None
-                                )
-                                break
-                            except ValueError:
-                                continue
-                    except Exception:
-                        pass
+                    # Try common formats
+                    for _fmt in ["%Y-%m-%d", "%m/%d/%Y", "%d-%m-%Y"]:
+                        try:
+                            completion_date = (
+                                date_type.fromisoformat(date_str)
+                                if "-" in date_str and len(date_str) == 10
+                                else None
+                            )
+                            break
+                        except ValueError:
+                            continue
 
                 items.append(
                     CompletedItem(

--- a/src/doit_cli/services/file_watcher_service.py
+++ b/src/doit_cli/services/file_watcher_service.py
@@ -6,6 +6,7 @@ This module provides the FileWatcherService class for monitoring
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -16,6 +17,8 @@ from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 from doit_cli.services.notification_service import NotificationService
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -197,12 +200,14 @@ class FileWatcherService:
 
         unique_changes = list(seen_paths.values())
 
-        # Call registered callbacks
+        # Call registered callbacks — user callbacks are untyped, so we
+        # must isolate any failure to avoid stalling the watcher. Exception
+        # is intentional here and the error is logged for debugging.
         for callback in self._on_change_callbacks:
             try:
                 callback(unique_changes)
             except Exception:
-                pass  # Don't let callback errors stop processing
+                logger.exception("file-change callback raised; continuing")
 
         # Create notification if there are file changes
         if unique_changes:

--- a/src/doit_cli/services/git_utils.py
+++ b/src/doit_cli/services/git_utils.py
@@ -118,9 +118,9 @@ def run_git_command(
         return cmd_result
 
     except subprocess.TimeoutExpired:
-        raise GitError("Git command timed out after 60 seconds")
+        raise GitError("Git command timed out after 60 seconds") from None
     except FileNotFoundError:
-        raise GitNotAvailableError("Git is not installed or not available in PATH")
+        raise GitNotAvailableError("Git is not installed or not available in PATH") from None
 
 
 def is_git_available() -> bool:

--- a/src/doit_cli/services/github_cache_service.py
+++ b/src/doit_cli/services/github_cache_service.py
@@ -67,9 +67,9 @@ class GitHubCacheService:
             return cache_data
 
         except json.JSONDecodeError as e:
-            raise CacheError(f"Corrupted cache file: {e}")
+            raise CacheError(f"Corrupted cache file: {e}") from e
         except OSError as e:
-            raise CacheError(f"Failed to read cache file: {e}")
+            raise CacheError(f"Failed to read cache file: {e}") from e
 
     def save_cache(self, epics: list[GitHubEpic], metadata: SyncMetadata) -> None:
         """Save epics and metadata to cache file.
@@ -104,7 +104,7 @@ class GitHubCacheService:
             temp_path.replace(self.cache_path)
 
         except OSError as e:
-            raise CacheError(f"Failed to write cache file: {e}")
+            raise CacheError(f"Failed to write cache file: {e}") from e
 
     def is_valid(self) -> bool:
         """Check if cache exists and is still valid based on TTL.
@@ -195,7 +195,7 @@ class GitHubCacheService:
             try:
                 self.cache_path.unlink()
             except OSError as e:
-                raise CacheError(f"Failed to delete cache file: {e}")
+                raise CacheError(f"Failed to delete cache file: {e}") from e
 
     def get_cache_age_minutes(self) -> float | None:
         """Get cache age in minutes.

--- a/src/doit_cli/services/github_linker.py
+++ b/src/doit_cli/services/github_linker.py
@@ -156,7 +156,7 @@ class GitHubLinkerService:
             self._update_epic_via_cli(epic_number, new_body)
 
         except subprocess.CalledProcessError as e:
-            raise GitHubServiceError(f"Failed to update epic #{epic_number}: {e}")
+            raise GitHubServiceError(f"Failed to update epic #{epic_number}: {e}") from e
 
     def get_epic_details(self, epic_number: int) -> dict:
         """Fetch epic details from GitHub API.
@@ -202,10 +202,10 @@ class GitHubLinkerService:
 
         except subprocess.CalledProcessError as e:
             if "404" in e.stderr:
-                raise GitHubServiceError(f"Epic #{epic_number} not found")
-            raise GitHubServiceError(f"Failed to fetch epic #{epic_number}: {e.stderr}")
+                raise GitHubServiceError(f"Epic #{epic_number} not found") from e
+            raise GitHubServiceError(f"Failed to fetch epic #{epic_number}: {e.stderr}") from e
         except subprocess.TimeoutExpired:
-            raise GitHubServiceError(f"Timeout fetching epic #{epic_number}")
+            raise GitHubServiceError(f"Timeout fetching epic #{epic_number}") from None
 
     def validate_epic_for_linking(self, epic_number: int) -> tuple[bool, str]:
         """Check if an epic can be linked to a spec.
@@ -377,7 +377,7 @@ class GitHubLinkerService:
             return slug
 
         except subprocess.CalledProcessError:
-            raise GitHubServiceError("Failed to get git remote URL")
+            raise GitHubServiceError("Failed to get git remote URL") from None
 
     def create_epic_for_roadmap_item(
         self, title: str, priority: str, feature_description: str | None = None
@@ -412,7 +412,7 @@ class GitHubLinkerService:
             return (epic.number, epic.url)
 
         except Exception as e:
-            raise GitHubServiceError(f"Failed to create epic: {e}")
+            raise GitHubServiceError(f"Failed to create epic: {e}") from e
 
     def update_roadmap_with_epic(
         self, roadmap_path: Path, roadmap_title: str, epic_number: int, epic_url: str

--- a/src/doit_cli/services/github_service.py
+++ b/src/doit_cli/services/github_service.py
@@ -96,7 +96,7 @@ class GitHubService:
         except FileNotFoundError:
             raise GitHubServiceError(
                 "GitHub CLI (gh) not found. Install it from https://cli.github.com/"
-            )
+            ) from None
 
     def _ensure_authenticated(self) -> None:
         """Verify GitHub CLI is available and authenticated.
@@ -295,13 +295,13 @@ class GitHubService:
             raise GitHubAPIError(
                 f"GitHub CLI timeout after {self.timeout} seconds. "
                 "Try increasing timeout or use --skip-github flag."
-            )
+            ) from None
         except json.JSONDecodeError as e:
-            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}")
+            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}") from e
         except FileNotFoundError:
             raise GitHubAuthError(
                 "GitHub CLI (gh) not found in PATH. Install from: https://cli.github.com"
-            )
+            ) from None
 
     def fetch_features_for_epic(self, epic_number: int) -> list[GitHubFeature]:  # type: ignore
         """Fetch all feature issues linked to a specific epic.
@@ -369,9 +369,9 @@ class GitHubService:
             return features
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds")
+            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds") from None
         except json.JSONDecodeError as e:
-            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}")
+            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}") from e
 
     def create_epic(
         self, title: str, body: str, priority: str = "P3", labels: list[str] | None = None
@@ -450,9 +450,9 @@ class GitHubService:
             )
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds")
+            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds") from None
         except (ValueError, IndexError) as e:
-            raise GitHubAPIError(f"Failed to parse created issue URL: {e}")
+            raise GitHubAPIError(f"Failed to parse created issue URL: {e}") from e
 
     # ==========================================================================
     # Milestone Operations
@@ -528,9 +528,9 @@ class GitHubService:
             return milestones
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds.")
+            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds.") from None
         except json.JSONDecodeError as e:
-            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}")
+            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}") from e
 
     def create_milestone(self, title: str, description: str) -> Milestone:
         """Create a new GitHub milestone.
@@ -601,9 +601,9 @@ class GitHubService:
             )
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds")
+            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds") from None
         except json.JSONDecodeError as e:
-            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}")
+            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}") from e
 
     def close_milestone(self, milestone_number: int) -> Milestone:
         """Close a GitHub milestone.
@@ -666,9 +666,9 @@ class GitHubService:
             )
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds")
+            raise GitHubAPIError(f"GitHub CLI timeout after {self.timeout} seconds") from None
         except json.JSONDecodeError as e:
-            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}")
+            raise GitHubAPIError(f"Failed to parse GitHub CLI response: {e}") from e
 
     # ==========================================================================
     # Branch Operations
@@ -767,6 +767,6 @@ class GitHubService:
             return slug
 
         except subprocess.TimeoutExpired:
-            raise GitHubAPIError("Git command timeout")
+            raise GitHubAPIError("Git command timeout") from None
         except Exception as e:
-            raise GitHubAPIError(f"Failed to get repository slug: {e}")
+            raise GitHubAPIError(f"Failed to get repository slug: {e}") from e

--- a/src/doit_cli/services/hook_validator.py
+++ b/src/doit_cli/services/hook_validator.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import fnmatch
+import logging
 import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
 
 from ..models.hook_config import HookConfig
+
+logger = logging.getLogger(__name__)
 
 
 class ValidationResult:
@@ -371,8 +374,9 @@ class HookValidator:
             # ValidationService not available - skip validation
             pass
         except Exception:
-            # Log error but don't block commit for validation failures
-            pass
+            # Any unexpected ValidationService failure is logged but must not
+            # block the commit — hook validation is advisory, not blocking.
+            logger.exception("spec validation failed unexpectedly; skipping gate")
 
         return ValidationResult(True, "Spec validation passed")
 

--- a/src/doit_cli/services/memory_search.py
+++ b/src/doit_cli/services/memory_search.py
@@ -219,7 +219,7 @@ class MemorySearchService:
         try:
             regex = re.compile(pattern, flags)
         except re.error as e:
-            raise ValueError(f"Invalid regex pattern: {e}")
+            raise ValueError(f"Invalid regex pattern: {e}") from e
 
         # Search each file
         for file_path in files:

--- a/src/doit_cli/services/milestone_service.py
+++ b/src/doit_cli/services/milestone_service.py
@@ -357,9 +357,9 @@ class MilestoneService:
                 raise GitHubServiceError(f"Failed to assign epic: {result.stderr}")
 
         except subprocess.TimeoutExpired:
-            raise GitHubServiceError("GitHub CLI timeout")
+            raise GitHubServiceError("GitHub CLI timeout") from None
         except Exception as e:
-            raise GitHubServiceError(f"Failed to assign epic: {e}")
+            raise GitHubServiceError(f"Failed to assign epic: {e}") from e
 
     def detect_completed_priorities(self) -> list[str]:
         """Check roadmap.md and completed_roadmap.md for empty priority sections.

--- a/src/doit_cli/services/providers/azure_devops.py
+++ b/src/doit_cli/services/providers/azure_devops.py
@@ -168,9 +168,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_work_item(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def get_issue(self, issue_id: str) -> Issue:
         """Get an Azure DevOps work item by ID."""
@@ -198,9 +198,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_work_item(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
         """List Azure DevOps work items matching filters."""
@@ -263,9 +263,9 @@ class AzureDevOpsProvider(GitProvider):
             return issues
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
         """Update an Azure DevOps work item."""
@@ -318,9 +318,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_work_item(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     # -------------------------------------------------------------------------
     # Pull Request Operations
@@ -363,9 +363,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_pull_request(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def get_pull_request(self, pr_id: str) -> PullRequest:
         """Get an Azure DevOps pull request by ID."""
@@ -394,9 +394,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_pull_request(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def list_pull_requests(self, filters: PRFilters | None = None) -> list[PullRequest]:
         """List Azure DevOps pull requests matching filters."""
@@ -439,9 +439,9 @@ class AzureDevOpsProvider(GitProvider):
             return [self._parse_pull_request(pr) for pr in data.get("value", [])]
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     # -------------------------------------------------------------------------
     # Milestone Operations (Iterations)
@@ -482,9 +482,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_iteration(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def get_milestone(self, milestone_id: str) -> Milestone:
         """Get an Azure DevOps iteration by ID."""
@@ -512,9 +512,9 @@ class AzureDevOpsProvider(GitProvider):
             return self._parse_iteration(data)
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def list_milestones(self, state: MilestoneState | None = None) -> list[Milestone]:
         """List Azure DevOps iterations."""
@@ -547,9 +547,9 @@ class AzureDevOpsProvider(GitProvider):
             return milestones
 
         except httpx.TimeoutException:
-            raise NetworkError("Azure DevOps API timeout", is_timeout=True)
+            raise NetworkError("Azure DevOps API timeout", is_timeout=True) from None
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     # -------------------------------------------------------------------------
     # Helper Methods
@@ -614,7 +614,7 @@ class AzureDevOpsProvider(GitProvider):
             return repos[0]["id"]
 
         except httpx.RequestError as e:
-            raise NetworkError(f"Azure DevOps network error: {e}")
+            raise NetworkError(f"Azure DevOps network error: {e}") from e
 
     def _parse_work_item(self, data: dict) -> Issue:
         """Parse Azure DevOps work item into Issue model."""

--- a/src/doit_cli/services/providers/github.py
+++ b/src/doit_cli/services/providers/github.py
@@ -152,7 +152,7 @@ class GitHubProvider(GitProvider):
             return self.get_issue(issue_number)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
 
     def get_issue(self, issue_id: str) -> Issue:
         """Get a GitHub issue by number."""
@@ -183,9 +183,9 @@ class GitHubProvider(GitProvider):
             return self._parse_issue(data)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
         """List GitHub issues matching filters."""
@@ -229,9 +229,9 @@ class GitHubProvider(GitProvider):
             return [self._parse_issue(item) for item in data]
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     def update_issue(self, issue_id: str, updates: IssueUpdateRequest) -> Issue:
         """Update a GitHub issue."""
@@ -279,7 +279,7 @@ class GitHubProvider(GitProvider):
             return self.get_issue(provider_id)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
 
     # -------------------------------------------------------------------------
     # Pull Request Operations
@@ -325,7 +325,7 @@ class GitHubProvider(GitProvider):
             return self.get_pull_request(pr_number)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
 
     def get_pull_request(self, pr_id: str) -> PullRequest:
         """Get a GitHub pull request by number."""
@@ -356,9 +356,9 @@ class GitHubProvider(GitProvider):
             return self._parse_pull_request(data)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     def list_pull_requests(self, filters: PRFilters | None = None) -> list[PullRequest]:
         """List GitHub pull requests matching filters."""
@@ -405,9 +405,9 @@ class GitHubProvider(GitProvider):
             return [self._parse_pull_request(item) for item in data]
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     # -------------------------------------------------------------------------
     # Milestone Operations
@@ -453,9 +453,9 @@ class GitHubProvider(GitProvider):
             return self._parse_milestone(data)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     def get_milestone(self, milestone_id: str) -> Milestone:
         """Get a GitHub milestone by number."""
@@ -480,9 +480,9 @@ class GitHubProvider(GitProvider):
             return self._parse_milestone(data)
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     def list_milestones(self, state: MilestoneState | None = None) -> list[Milestone]:
         """List GitHub milestones."""
@@ -510,9 +510,9 @@ class GitHubProvider(GitProvider):
             return [self._parse_milestone(item) for item in data]
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("GitHub CLI timeout", is_timeout=True)
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
         except json.JSONDecodeError as e:
-            raise ProviderError(f"Failed to parse GitHub response: {e}")
+            raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     # -------------------------------------------------------------------------
     # Helper Methods
@@ -536,7 +536,7 @@ class GitHubProvider(GitProvider):
             raise AuthenticationError(
                 "GitHub CLI (gh) not installed. Install from: https://cli.github.com",
                 provider="GitHub",
-            )
+            ) from None
 
     def _handle_error(self, stderr: str) -> None:
         """Convert gh CLI error to appropriate exception."""
@@ -579,7 +579,7 @@ class GitHubProvider(GitProvider):
             return slug
 
         except subprocess.TimeoutExpired:
-            raise NetworkError("Git command timeout", is_timeout=True)
+            raise NetworkError("Git command timeout", is_timeout=True) from None
 
     def _parse_issue(self, data: dict) -> Issue:
         """Parse gh CLI JSON output into Issue model."""

--- a/src/doit_cli/services/providers/gitlab.py
+++ b/src/doit_cli/services/providers/gitlab.py
@@ -293,18 +293,18 @@ class GitLabAPIClient:
                 f"SSL certificate error connecting to {self.host}. "
                 "For self-hosted GitLab, ensure your certificate is valid.",
                 cause=e,
-            )
+            ) from e
         except httpx.TimeoutException as e:
             raise NetworkError(
                 "Request timed out. Check your network connection.",
                 cause=e,
                 is_timeout=True,
-            )
+            ) from e
         except httpx.ConnectError as e:
             raise NetworkError(
                 f"Could not connect to {self.host}. Check your network connection.",
                 cause=e,
-            )
+            ) from e
 
     def get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Make a GET request to the GitLab API.
@@ -723,7 +723,7 @@ class GitLabProvider(GitProvider):
             data = self._api.get(f"/projects/{self._encoded_path}/issues/{iid}")
             return self._parse_issue(data)
         except ResourceNotFoundError:
-            raise ResourceNotFoundError("Issue", issue_id)
+            raise ResourceNotFoundError("Issue", issue_id) from None
 
     @with_retry(max_retries=3)
     def list_issues(self, filters: IssueFilters | None = None) -> list[Issue]:
@@ -793,7 +793,7 @@ class GitLabProvider(GitProvider):
             data = self._api.put(f"/projects/{self._encoded_path}/issues/{iid}", payload)
             return self._parse_issue(data)
         except ResourceNotFoundError:
-            raise ResourceNotFoundError("Issue", issue_id)
+            raise ResourceNotFoundError("Issue", issue_id) from None
 
     # -------------------------------------------------------------------------
     # Pull Request (Merge Request) Operations
@@ -847,7 +847,7 @@ class GitLabProvider(GitProvider):
             data = self._api.get(f"/projects/{self._encoded_path}/merge_requests/{iid}")
             return self._parse_pull_request(data)
         except ResourceNotFoundError:
-            raise ResourceNotFoundError("Merge Request", pr_id)
+            raise ResourceNotFoundError("Merge Request", pr_id) from None
 
     @with_retry(max_retries=3)
     def list_pull_requests(self, filters: PRFilters | None = None) -> list[PullRequest]:
@@ -931,7 +931,7 @@ class GitLabProvider(GitProvider):
             data = self._api.get(f"/projects/{self._encoded_path}/milestones/{ms_id}")
             return self._parse_milestone(data)
         except ResourceNotFoundError:
-            raise ResourceNotFoundError("Milestone", milestone_id)
+            raise ResourceNotFoundError("Milestone", milestone_id) from None
 
     @with_retry(max_retries=3)
     def list_milestones(self, state: MilestoneState | None = None) -> list[Milestone]:
@@ -994,4 +994,4 @@ class GitLabProvider(GitProvider):
             data = self._api.put(f"/projects/{self._encoded_path}/milestones/{ms_id}", payload)
             return self._parse_milestone(data)
         except ResourceNotFoundError:
-            raise ResourceNotFoundError("Milestone", milestone_id)
+            raise ResourceNotFoundError("Milestone", milestone_id) from None

--- a/src/doit_cli/services/rule_engine.py
+++ b/src/doit_cli/services/rule_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -13,6 +14,8 @@ from ..models.validation_models import (
     ValidationRule,
 )
 from ..rules.builtin_rules import get_builtin_rules
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     pass
@@ -435,9 +438,9 @@ class RuleEngine:
                         )
                     )
 
-        except Exception:
-            # If cross-reference validation fails, skip silently
-            # (e.g., spec not found, parsing errors)
-            pass
+        except (OSError, ValueError, KeyError) as exc:
+            # Cross-reference validation is best-effort — missing specs or
+            # malformed requirement lists should not block the rule run.
+            logger.debug("cross-reference validation skipped: %s", exc)
 
         return issues

--- a/src/doit_cli/services/state_manager.py
+++ b/src/doit_cli/services/state_manager.py
@@ -228,11 +228,11 @@ class StateManager:
                 data = json.load(f)
             return WorkflowState.from_dict(data)
         except json.JSONDecodeError as e:
-            raise StateCorruptionError(filepath, f"Invalid JSON: {e}")
+            raise StateCorruptionError(filepath, f"Invalid JSON: {e}") from e
         except KeyError as e:
-            raise StateCorruptionError(filepath, f"Missing required field: {e}")
+            raise StateCorruptionError(filepath, f"Missing required field: {e}") from e
         except Exception as e:
-            raise StateCorruptionError(filepath, f"Failed to load: {e}")
+            raise StateCorruptionError(filepath, f"Failed to load: {e}") from e
 
     # =========================================================================
     # Fixit Workflow State Methods (T013)

--- a/src/doit_cli/services/team_config.py
+++ b/src/doit_cli/services/team_config.py
@@ -137,7 +137,7 @@ def load_team_config(project_root: Path | None = None) -> TeamConfig:
         with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        raise TeamConfigValidationError(f"Invalid YAML in team.yaml: {e}")
+        raise TeamConfigValidationError(f"Invalid YAML in team.yaml: {e}") from e
 
     if not data:
         raise TeamConfigValidationError("team.yaml is empty")
@@ -145,7 +145,7 @@ def load_team_config(project_root: Path | None = None) -> TeamConfig:
     try:
         config = TeamConfig.from_dict(data)
     except (KeyError, ValueError) as e:
-        raise TeamConfigValidationError(f"Invalid team configuration: {e}")
+        raise TeamConfigValidationError(f"Invalid team configuration: {e}") from e
 
     # Validate configuration
     errors = validate_team_config(config)

--- a/src/doit_cli/services/template_manager.py
+++ b/src/doit_cli/services/template_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 from pathlib import Path
 
@@ -9,6 +10,8 @@ from ..models.agent import Agent
 from ..models.sync_models import CommandTemplate
 from ..models.template import DOIT_COMMANDS, Template
 from .prompt_transformer import PromptTransformer
+
+logger = logging.getLogger(__name__)
 
 # Workflow templates to copy to .doit/templates/
 WORKFLOW_TEMPLATES = [
@@ -143,8 +146,10 @@ class TemplateManager:
                 try:
                     template = Template.from_file(file_path, agent)
                     templates.append(template)
-                except Exception:
-                    # Skip files that can't be parsed
+                except (OSError, ValueError, UnicodeDecodeError) as exc:
+                    # Skip files that can't be parsed; log for debugging but
+                    # don't fail the whole scan for a single bad file.
+                    logger.debug("skipping unparseable template %s: %s", file_path, exc)
                     continue
 
         return templates
@@ -280,8 +285,8 @@ class TemplateManager:
                     # Always parse as Claude format since source is commands/
                     template = Template.from_file(file_path, Agent.CLAUDE)
                     templates.append(template)
-                except Exception:
-                    # Skip files that can't be parsed
+                except (OSError, ValueError, UnicodeDecodeError) as exc:
+                    logger.debug("skipping unparseable template %s: %s", file_path, exc)
                     continue
 
         return templates

--- a/src/doit_cli/services/wizard_service.py
+++ b/src/doit_cli/services/wizard_service.py
@@ -423,8 +423,12 @@ class WizardService:
                     config = self.backup.restore_backup(latest.backup_id)
                     config.save()
                     self.console.print("[dim]Previous configuration restored from backup.[/dim]")
-                except Exception:
-                    pass
+                except (OSError, ValueError) as exc:
+                    # Restore is best-effort on cancel — surface a hint,
+                    # don't re-raise since the user already cancelled.
+                    self.console.print(
+                        f"[yellow]Could not restore backup automatically: {exc}[/yellow]"
+                    )
 
     def _display_header(self) -> None:
         """Display wizard header."""

--- a/src/doit_cli/utils/spec_parser.py
+++ b/src/doit_cli/utils/spec_parser.py
@@ -139,7 +139,7 @@ def parse_spec_file(spec_path: Path) -> tuple[SpecFrontmatter, str]:
         return (frontmatter, body)
 
     except (ValueError, yaml.YAMLError) as e:
-        raise ValueError(f"Malformed frontmatter in {spec_path}: {e}")
+        raise ValueError(f"Malformed frontmatter in {spec_path}: {e}") from e
 
 
 def update_spec_frontmatter(spec_path: Path, updates: dict[str, Any]) -> None:

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,45 @@
+"""Tests for the shared DoitError hierarchy."""
+
+from __future__ import annotations
+
+import pytest
+
+from doit_cli.errors import (
+    DoitAuthError,
+    DoitConfigError,
+    DoitError,
+    DoitProviderError,
+    DoitStateError,
+    DoitTemplateError,
+    DoitValidationError,
+)
+
+
+class TestDoitErrorHierarchy:
+    """The hierarchy must let callers catch by category."""
+
+    def test_all_subclass_doit_error(self):
+        for subclass in (
+            DoitConfigError,
+            DoitStateError,
+            DoitTemplateError,
+            DoitProviderError,
+            DoitAuthError,
+            DoitValidationError,
+        ):
+            assert issubclass(subclass, DoitError)
+
+    def test_auth_error_is_provider_error(self):
+        assert issubclass(DoitAuthError, DoitProviderError)
+
+    def test_catching_base_catches_subclass(self):
+        with pytest.raises(DoitError):
+            raise DoitConfigError("missing field")
+
+    def test_catching_provider_catches_auth(self):
+        with pytest.raises(DoitProviderError):
+            raise DoitAuthError("token expired")
+
+    def test_carries_message(self):
+        err = DoitValidationError("bad input")
+        assert str(err) == "bad input"

--- a/tests/utils/windows/powershell_executor.py
+++ b/tests/utils/windows/powershell_executor.py
@@ -38,10 +38,12 @@ class PowerShellExecutor:
             )
             if result.returncode != 0:
                 raise RuntimeError("PowerShell Core (pwsh) not available")
-        except FileNotFoundError:
-            raise RuntimeError("PowerShell Core (pwsh) not found. Please install PowerShell 7.x")
-        except subprocess.TimeoutExpired:
-            raise RuntimeError("PowerShell verification timed out")
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "PowerShell Core (pwsh) not found. Please install PowerShell 7.x"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError("PowerShell verification timed out") from e
 
     def run_script(
         self,


### PR DESCRIPTION
## Summary

Phase 2 of the April 2026 modernization. Stacked on Phase 1 PR (#788).

- **DoitError hierarchy** (`src/doit_cli/errors.py`): `DoitError` base with category subclasses (`DoitConfigError`, `DoitStateError`, `DoitTemplateError`, `DoitProviderError` + `DoitAuthError`, `DoitValidationError`). Legacy per-module hierarchies continue working; they'll be re-parented in follow-up PRs.
- **Exception chaining**: all 155 `B904` findings fixed. Every `raise X(...)` inside an `except` now carries `from e` (preserving the chain where a variable is captured) or `from None` (when the original is truly irrelevant). An AST-based script applied the transform mechanically.
- **Silent-pass cleanup**: the 11 `except Exception: pass|continue` sites audited individually — narrowed to specific exception types, or switched to `logger.debug/exception` where the broad catch is intentional (e.g. user callbacks in the file watcher).
- **Ruff**: `B904` removed from the deferred-rules list in `pyproject.toml` now that the backlog is zero.
- **Tests**: `tests/unit/test_errors.py` verifies the hierarchy catches correctly.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] 1,735 unit + contract + integration tests pass (1,730 + 5 new)
- [x] No behavior change on success paths; only the suppressed-error paths now log or carry `__cause__`
- [ ] CI green on Ubuntu / macOS / Windows

## Related

PR #788 (Phase 1) ← this PR stacks on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)