### PR TITLE
fix(copilot): PromptTransformer emits native .prompt.md frontmatter (Phase 6)

### DIFF
--- a/.github/prompts/doit.checkin.prompt.md
+++ b/.github/prompts/doit.checkin.prompt.md
@@ -1,14 +1,18 @@
 ---
-description: Finalize feature implementation, close issues, update roadmaps, and create pull request
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
+description: Finalize feature implementation, close issues, update roadmaps, and create
+  pull request
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
+- githubRepo
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -249,7 +253,7 @@ Before generating or modifying code:
 
 9. **Create pull request**:
    - Determine target branch:
-     - Check $ARGUMENTS for `--target [branch]` flag
+     - Check ${input:args} for `--target [branch]` flag
      - If not specified, check for `develop` branch
      - If no `develop`, use `main` or `master`
    - Check for gh CLI:

--- a/.github/prompts/doit.constitution.prompt.md
+++ b/.github/prompts/doit.constitution.prompt.md
@@ -1,18 +1,17 @@
 ---
-description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Build Specification
-    agent: doit.doit
-    prompt: Implement the feature specification based on the updated constitution. I want to build...
+description: Create or update the project constitution from interactive or provided
+  principle inputs, ensuring all dependent templates stay in sync.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 

--- a/.github/prompts/doit.documentit.prompt.md
+++ b/.github/prompts/doit.documentit.prompt.md
@@ -1,21 +1,17 @@
 ---
-description: Organize, index, audit, and enhance project documentation aligned with scaffoldit conventions.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Run Scaffoldit
-    agent: doit.scaffoldit
-    prompt: Scaffold project structure and generate tech-stack.md...
-  - label: Create Specification
-    agent: doit.specit
-    prompt: Create a feature specification...
+description: Organize, index, audit, and enhance project documentation aligned with
+  scaffoldit conventions.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -72,7 +68,7 @@ If no subcommand is provided, show an interactive menu.
 
 ## Subcommand Detection
 
-Parse $ARGUMENTS to detect the operation:
+Parse ${input:args} to detect the operation:
 
 1. **If empty**: Show interactive menu (step 1)
 2. **If starts with "organize"**: Execute organize workflow (step 2)

--- a/.github/prompts/doit.fixit.prompt.md
+++ b/.github/prompts/doit.fixit.prompt.md
@@ -1,27 +1,17 @@
 ---
 description: Start and manage bug-fix workflows for GitHub issues
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Create Plan
-    agent: doit.planit
-    prompt: Create fix plan from investigation findings
-    send: true
-  - label: Implement Fix
-    agent: doit.implementit
-    prompt: Execute the fix plan tasks
-    send: true
-  - label: Check In
-    agent: doit.checkin
-    prompt: Finalize fix and create pull request
-    send: true
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
+- githubRepo
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -70,7 +60,7 @@ This command manages the bug-fix workflow lifecycle for GitHub issues.
 
 ### 1. Parse Command Arguments
 
-Extract the operation from `$ARGUMENTS`:
+Extract the operation from `${input:args}`:
 
 | Pattern | Operation | Example |
 |---------|-----------|---------|

--- a/.github/prompts/doit.implementit.prompt.md
+++ b/.github/prompts/doit.implementit.prompt.md
@@ -1,23 +1,17 @@
 ---
-description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Review Implementation
-    agent: doit.review
-    prompt: Review the implemented code for quality and completeness
-    send: true
-  - label: Run Tests
-    agent: doit.test
-    prompt: Execute automated tests and generate test report
-    send: true
+description: Execute the implementation plan by processing and executing all tasks
+  defined in tasks.md
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -65,7 +59,7 @@ Before generating or modifying code:
 1. Run `.doit/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
-   - Check for `--skip-checklist` in $ARGUMENTS - if present, skip checklist verification
+   - Check for `--skip-checklist` in ${input:args} - if present, skip checklist verification
    - If not skipped, scan all checklist files in the checklists/ directory
    - For each checklist, count:
      - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`

--- a/.github/prompts/doit.planit.prompt.md
+++ b/.github/prompts/doit.planit.prompt.md
@@ -1,22 +1,17 @@
 ---
-description: Execute the implementation planning workflow using the plan template to generate design artifacts.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs: 
-  - label: Create Tasks
-    agent: doit.tasks
-    prompt: Break the plan into tasks
-    send: true
-  - label: Create Checklist
-    agent: doit.checklist
-    prompt: Create a checklist for the following domain...
+description: Execute the implementation planning workflow using the plan template
+  to generate design artifacts.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 

--- a/.github/prompts/doit.researchit.prompt.md
+++ b/.github/prompts/doit.researchit.prompt.md
@@ -1,24 +1,24 @@
 ---
-description: Pre-specification research workflow for Product Owners to capture business requirements through interactive Q&A, generating research artifacts for handoff to technical specification.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Create Technical Specification
-    agent: doit.specit
-    prompt: Create a specification using the research artifacts from this session.
+description: Pre-specification research workflow for Product Owners to capture business
+  requirements through interactive Q&A, generating research artifacts for handoff
+  to technical specification.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty). The user input is the feature name or description they want to research.
 
 ### Flag Detection
 
-Check for the following flags in `$ARGUMENTS`:
+Check for the following flags in `${input:args}`:
 
 - `--auto-continue`: Skip handoff prompt and automatically invoke `/doit.specit` after research completes
 - `--skip-issues`: Skip GitHub issue creation (existing behavior)
@@ -74,7 +74,7 @@ ls specs/*/research.md 2>/dev/null | grep -i "$FEATURE_NAME" || echo "No existin
 
 ### Step 2: Establish Feature Context
 
-If `$ARGUMENTS` is empty, ask:
+If `${input:args}` is empty, ask:
 > "What feature or capability would you like to research? Please describe it in a sentence or two."
 
 Once you have the feature description:
@@ -278,7 +278,7 @@ If not already established, determine the feature number by finding the **highes
 ```bash
 # Find the highest feature number across all existing directories
 # This handles gaps (e.g., if 001, 002, 005 exist, next is 006)
-ls -d specs/[0-9][0-9][0-9]-* 2>/dev/null | sed 's/.*specs\/\([0-9]*\)-.*/\1/' | sort -n | tail -1 | awk '{printf "%03d", $1+1}'
+ls -d specs/[0-9][0-9][0-9]-* 2>/dev/null | sed 's/.*specs\/\([0-9]*\)-.*/\1/' | sort -n | tail -1 | awk '{printf "%03d", ${input:arg1}+1}'
 ```
 
 If no existing directories found, start with `001`.

--- a/.github/prompts/doit.reviewit.prompt.md
+++ b/.github/prompts/doit.reviewit.prompt.md
@@ -1,23 +1,16 @@
 ---
 description: Review implemented code for quality and completeness against specifications
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Run Tests
-    agent: doit.test
-    prompt: Execute automated tests and generate test report
-    send: true
-  - label: Check In
-    agent: doit.checkin
-    prompt: Finalize feature and create pull request
-    send: true
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 

--- a/.github/prompts/doit.roadmapit.prompt.md
+++ b/.github/prompts/doit.roadmapit.prompt.md
@@ -1,21 +1,18 @@
 ---
-description: Create or update the project roadmap with prioritized requirements, deferred functionality, and AI-suggested enhancements.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Create Specification
-    agent: doit.specit
-    prompt: Create a feature specification for the top roadmap item...
-  - label: Update Constitution
-    agent: doit.constitution
-    prompt: Update the project constitution based on roadmap priorities...
+description: Create or update the project roadmap with prioritized requirements, deferred
+  functionality, and AI-suggested enhancements.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
+- githubRepo
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -70,7 +67,7 @@ This command creates or updates the project roadmap at `.doit/memory/roadmap.md`
 
 ### 1. Parse Command Arguments
 
-Extract the operation and details from `$ARGUMENTS`:
+Extract the operation and details from `${input:args}`:
 
 | Pattern | Operation | Example |
 |---------|-----------|---------|

--- a/.github/prompts/doit.scaffoldit.prompt.md
+++ b/.github/prompts/doit.scaffoldit.prompt.md
@@ -1,24 +1,17 @@
 ---
-description: Generate project folder structure and starter files based on tech stack from constitution or user input.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Create Specification
-    agent: doit.specit
-    prompt: Create a feature specification for this scaffolded project. I want to build...
-  - label: Update Constitution
-    agent: doit.constitution
-    prompt: Update the project constitution with additional details...
-  - label: Organize Documentation
-    agent: doit.documentit
-    prompt: Organize and index the project documentation...
+description: Generate project folder structure and starter files based on tech stack
+  from constitution or user input.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 

--- a/.github/prompts/doit.specit.prompt.md
+++ b/.github/prompts/doit.specit.prompt.md
@@ -1,21 +1,18 @@
 ---
-description: Create or update the feature specification from a natural language feature description, with integrated ambiguity resolution and GitHub issue creation.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Build Technical Plan
-    agent: doit.plan
-    prompt: Create a plan for the spec. I am building with...
-  - label: Scaffold Project Structure
-    agent: doit.scaffold
-    prompt: Generate project structure based on constitution tech stack
+description: Create or update the feature specification from a natural language feature
+  description, with integrated ambiguity resolution and GitHub issue creation.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
+- githubRepo
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -229,7 +226,7 @@ After story generation and traceability update, display a Persona Coverage summa
 
 ## Outline
 
-The text the user typed after `/doit.doit` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+The text the user typed after `/doit.doit` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `${input:args}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 Given that feature description, do this:
 
@@ -263,10 +260,10 @@ Given that feature description, do this:
       - Find the highest number N
       - Use N+1 for the new branch number
 
-   d. Run the script `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
+   d. Run the script `.doit/scripts/bash/create-new-feature.sh --json "${input:args}"` with the calculated number and short-name:
       - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+      - Bash example: `.doit/scripts/bash/create-new-feature.sh --json "${input:args}" --json --number 5 --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.doit/scripts/bash/create-new-feature.sh --json "${input:args}" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
    - Check all three sources (remote branches, local branches, specs directories) to find the highest number

--- a/.github/prompts/doit.taskit.prompt.md
+++ b/.github/prompts/doit.taskit.prompt.md
@@ -1,23 +1,17 @@
 ---
-description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs: 
-  - label: Analyze For Consistency
-    agent: doit.analyze
-    prompt: Run a project analysis for consistency
-    send: true
-  - label: Implement Project
-    agent: doit.implement
-    prompt: Start the implementation in phases
-    send: true
+description: Generate an actionable, dependency-ordered tasks.md for the feature based
+  on available design artifacts.
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -185,7 +179,7 @@ Before generating or modifying code:
    - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
 
 7. **GitHub Issue Integration**:
-   - Check for `--skip-issues` in $ARGUMENTS - if present, skip issue creation
+   - Check for `--skip-issues` in ${input:args} - if present, skip issue creation
    - Detect GitHub remote: `git remote get-url origin`
    - If GitHub remote found and not skipped:
      - For each generated task, create a GitHub Task issue using the task.yml template
@@ -196,7 +190,7 @@ Before generating or modifying code:
    - If GitHub unavailable or API fails: Log warning and continue without issues
    - Report: Number of issues created, any linking errors
 
-Context for task generation: $ARGUMENTS
+Context for task generation: ${input:args}
 
 The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
 

--- a/.github/prompts/doit.testit.prompt.md
+++ b/.github/prompts/doit.testit.prompt.md
@@ -1,23 +1,16 @@
 ---
 description: Execute automated tests and generate test reports with requirement mapping
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-effort: high
-handoffs:
-  - label: Check In
-    agent: doit.checkin
-    prompt: Finalize feature and create pull request
-    send: true
-  - label: Review Again
-    agent: doit.review
-    prompt: Re-review code after test fixes
-    send: true
+agent: agent
+tools:
+- editFiles
+- search
+- codebase
+- runCommands
 ---
 
 ## User Input
 
-```text
-$ARGUMENTS
-```
+${input:args:Describe what you want to do for this command.}
 
 You **MUST** consider the user input before proceeding (if not empty).
 
@@ -166,7 +159,7 @@ Before generating or modifying code:
      ```
 
 8. **Record manual test results**:
-   - If $ARGUMENTS contains `--manual`:
+   - If ${input:args} contains `--manual`:
      - Present each manual test item
      - Ask for PASS/FAIL/SKIP result
      - Record notes for failed tests

--- a/src/doit_cli/services/prompt_transformer.py
+++ b/src/doit_cli/services/prompt_transformer.py
@@ -1,93 +1,182 @@
-"""Service to transform command templates to GitHub Copilot prompt format."""
+"""Transform doit command templates into GitHub Copilot `.prompt.md` files.
+
+The source templates in `src/doit_cli/templates/commands/` are authored for
+Claude Code (see https://code.claude.com/docs/en/skills) and carry Claude-
+specific frontmatter fields: `allowed-tools`, `handoffs`, `effort`. VS Code
+Copilot's `.prompt.md` spec (April 2026,
+https://code.visualstudio.com/docs/copilot/customization/prompt-files)
+recognizes a different set: `description`, `agent`, `tools`, `model`.
+
+This transformer:
+
+1. Rewrites frontmatter to the Copilot-native shape
+   (`description`, `agent: agent`, `tools: [...]`).
+2. Maps the Claude `allowed-tools` entries to VS Code tool identifiers via
+   a table. GitHub CLI-heavy commands also get the `githubRepo` tool.
+3. Rewrites `$ARGUMENTS` / `$N` placeholders to Copilot's `${input:...}`
+   variable syntax so the prompt prompts the user at invocation time.
+
+The body (markdown content below the frontmatter) is preserved verbatim
+apart from the placeholder rewrite — instructions that work for Claude
+generally work for Copilot once tool names are normalized.
+"""
 
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is a hard dependency
+    yaml = None  # type: ignore[assignment]
 
 from ..models.sync_models import CommandTemplate
 
+# Mapping: Claude `allowed-tools` token -> Copilot tool identifier(s).
+# Claude tools are coarse-grained verbs; Copilot tools are named after
+# the VS Code feature they expose. Multiple Claude tools can map to the
+# same Copilot tool — we deduplicate at the end.
+_CLAUDE_TO_COPILOT_TOOLS: dict[str, tuple[str, ...]] = {
+    "Read": ("editFiles",),
+    "Write": ("editFiles",),
+    "Edit": ("editFiles",),
+    "Glob": ("search", "codebase"),
+    "Grep": ("search", "codebase"),
+    "Bash": ("runCommands",),
+}
+
+# If the body mentions the `gh` CLI, also grant githubRepo so Copilot can
+# read issues/PRs directly. Heuristic; the alternative is per-template
+# metadata which isn't worth the extra frontmatter in every file.
+_GH_MARKERS = ("gh pr", "gh issue", "gh api", "gh auth")
+
 
 class PromptTransformer:
-    """Transforms doit command templates to GitHub Copilot prompt format."""
+    """Rewrites a Claude-format command template as a Copilot `.prompt.md`."""
 
     def transform(self, template: CommandTemplate) -> str:
-        """Transform a command template to Copilot prompt format.
+        """Return the Copilot-native prompt content for `template`."""
+        source_fm, body = _split_frontmatter(template.content)
+        copilot_fm = self._build_copilot_frontmatter(source_fm, body)
+        new_body = self._rewrite_placeholders(body)
+        return _render(copilot_fm, new_body)
 
-        Transformation rules (from research.md):
-        - Remove YAML frontmatter entirely (Copilot prompts are plain markdown)
-        - Replace $ARGUMENTS with natural language
-        - Preserve ## Outline, ## Key Rules, and other sections
+    # -- frontmatter -----------------------------------------------------
 
-        Args:
-            template: The command template to transform.
+    def _build_copilot_frontmatter(
+        self, source_fm: dict[str, object], body: str
+    ) -> dict[str, object]:
+        """Map Claude frontmatter to the VS Code Copilot schema.
 
-        Returns:
-            Transformed content suitable for Copilot prompt file.
+        Drops: `allowed-tools`, `handoffs`, `effort` (not VS Code-recognized).
+        Keeps: `description`, `model` (if present and valid).
+        Adds: `agent: agent`, `tools: [...]` (derived from allowed-tools + body).
         """
-        content = template.content
+        out: dict[str, object] = {}
+        description = source_fm.get("description")
+        if description:
+            out["description"] = str(description).strip()
 
-        # Step 1: Strip YAML frontmatter
-        content = self._strip_yaml_frontmatter(content)
+        out["agent"] = "agent"
 
-        # Step 2: Add description as header if available
-        if template.description:
-            header = f"# {self._title_from_name(template.name)}\n\n{template.description}\n\n"
-            content = header + content.lstrip()
+        tools = self._derive_tools(source_fm.get("allowed-tools", ""), body)
+        if tools:
+            out["tools"] = tools
 
-        # Step 3: Replace $ARGUMENTS placeholder with natural language
-        content = self._replace_arguments_placeholder(content)
+        # Pass through model if the source overrode it — VS Code accepts it.
+        model = source_fm.get("model")
+        if model:
+            out["model"] = str(model)
 
-        return content.strip() + "\n"
+        return out
 
-    def _strip_yaml_frontmatter(self, content: str) -> str:
-        """Remove YAML frontmatter from content.
+    def _derive_tools(self, allowed_tools: object, body: str) -> list[str]:
+        """Return the Copilot `tools:` list for this template."""
+        tokens = _tokenize_allowed_tools(allowed_tools)
+        mapped: list[str] = []
+        for tok in tokens:
+            for copilot_tool in _CLAUDE_TO_COPILOT_TOOLS.get(tok, ()):
+                if copilot_tool not in mapped:
+                    mapped.append(copilot_tool)
 
-        Args:
-            content: Markdown content potentially with YAML frontmatter.
+        if any(marker in body for marker in _GH_MARKERS) and "githubRepo" not in mapped:
+            mapped.append("githubRepo")
 
-        Returns:
-            Content with frontmatter removed.
-        """
-        if not content.startswith("---"):
-            return content
+        return mapped
 
-        # Find the closing ---
-        try:
-            end_idx = content.index("---", 3)
-            # Skip the closing --- and any trailing newline
-            return content[end_idx + 3 :].lstrip("\n")
-        except ValueError:
-            # No closing ---, return original
-            return content
+    # -- body placeholders ----------------------------------------------
 
-    def _replace_arguments_placeholder(self, content: str) -> str:
-        """Replace $ARGUMENTS placeholder with natural language.
+    def _rewrite_placeholders(self, body: str) -> str:
+        """Convert Claude `$ARGUMENTS` / `$N` to Copilot `${input:...}` variables."""
+        # The canonical user-input code block at the top of most templates.
+        body = re.sub(
+            r"```text\s*\n\$ARGUMENTS\s*\n```",
+            "${input:args:Describe what you want to do for this command.}",
+            body,
+        )
+        # Any remaining standalone $ARGUMENTS references.
+        body = body.replace("$ARGUMENTS", "${input:args}")
 
-        Args:
-            content: Content potentially containing $ARGUMENTS.
+        # Positional arguments: $0, $1, $2 -> ${input:argN}
+        def positional_sub(match: re.Match[str]) -> str:
+            index = int(match.group(1))
+            return f"${{input:arg{index}}}"
 
-        Returns:
-            Content with placeholder replaced.
-        """
-        # Replace the code block containing $ARGUMENTS
-        pattern = r"```text\s*\n\$ARGUMENTS\s*\n```"
-        replacement = "Consider any arguments or options the user provides."
-        content = re.sub(pattern, replacement, content)
+        body = re.sub(r"\$(\d+)\b", positional_sub, body)
+        return body
 
-        # Also replace standalone $ARGUMENTS references
-        content = content.replace("$ARGUMENTS", "the user's input")
 
-        return content
+# --------------------------------------------------------------------------
+# helpers
 
-    def _title_from_name(self, name: str) -> str:
-        """Convert command name to title case.
 
-        Args:
-            name: Command name like "doit.checkin".
+def _tokenize_allowed_tools(value: object) -> list[str]:
+    """Normalize the `allowed-tools` value into a flat list of tool names.
 
-        Returns:
-            Title like "Doit Checkin".
-        """
-        # doit.checkin -> Doit Checkin
-        parts = name.replace("doit.", "").split(".")
-        return "Doit " + " ".join(p.title() for p in parts)
+    Claude Code accepts both comma-separated strings and YAML lists, and
+    allows `Bash(pattern)` constraints; this strips the parenthesized
+    constraints and returns just the tool name.
+    """
+    if isinstance(value, list):
+        items: Iterable[str] = (str(v) for v in value)
+    else:
+        text = str(value).replace(",", " ")
+        items = text.split()
+
+    result: list[str] = []
+    for item in items:
+        name = re.sub(r"\(.*?\)", "", item).strip()
+        if name and name not in result:
+            result.append(name)
+    return result
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
+    """Split YAML frontmatter from the body. Returns ({}, raw) if absent."""
+    if not raw.startswith("---"):
+        return {}, raw
+
+    try:
+        end = raw.index("\n---", 3)
+    except ValueError:
+        return {}, raw  # malformed; leave body untouched
+
+    fm_text = raw[3:end].strip()
+    body = raw[end + len("\n---") :].lstrip("\n")
+
+    if yaml is None:  # pragma: no cover
+        return {}, body
+
+    parsed = yaml.safe_load(fm_text) or {}
+    if not isinstance(parsed, dict):
+        return {}, body
+    return parsed, body
+
+
+def _render(frontmatter: dict[str, object], body: str) -> str:
+    """Serialize frontmatter + body back into a `.prompt.md` string."""
+    if yaml is None:  # pragma: no cover
+        return body
+    dumped = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False).strip()
+    return f"---\n{dumped}\n---\n\n{body.lstrip()}"

--- a/tests/contract/test_copilot_prompt_format.py
+++ b/tests/contract/test_copilot_prompt_format.py
@@ -1,0 +1,114 @@
+"""Contract: every shipped .github/prompts/*.prompt.md matches the April 2026 Copilot spec.
+
+If this test fails after editing a source template, regenerate the
+prompts with `doit sync-prompts` (or run the transformer directly) and
+commit the result — the two directories must stay in sync.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from doit_cli.models.sync_models import CommandTemplate
+from doit_cli.services.prompt_transformer import PromptTransformer
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROMPTS_DIR = REPO_ROOT / ".github" / "prompts"
+COMMANDS_DIR = REPO_ROOT / "src" / "doit_cli" / "templates" / "commands"
+
+# Fields VS Code recognizes per https://code.visualstudio.com/docs/copilot/customization/prompt-files
+# (April 2026). Anything else in the frontmatter is considered a leak.
+ALLOWED_COPILOT_FIELDS = {"description", "agent", "tools", "model", "mode"}
+FORBIDDEN_CLAUDE_FIELDS = {"allowed-tools", "handoffs", "effort", "argument-hint", "when_to_use"}
+
+
+def _collect_prompts() -> list[Path]:
+    return sorted(PROMPTS_DIR.glob("doit.*.prompt.md"))
+
+
+@pytest.mark.parametrize("prompt_path", _collect_prompts(), ids=lambda p: p.name)
+class TestCopilotPromptFrontmatter:
+    """Per-file assertions on the shipped prompts."""
+
+    def test_has_frontmatter(self, prompt_path: Path) -> None:
+        content = prompt_path.read_text(encoding="utf-8")
+        assert content.startswith("---\n"), f"{prompt_path.name} is missing frontmatter"
+
+    def test_frontmatter_only_uses_allowed_fields(self, prompt_path: Path) -> None:
+        fm = _load_frontmatter(prompt_path)
+        unknown = set(fm) - ALLOWED_COPILOT_FIELDS
+        assert not unknown, (
+            f"{prompt_path.name} frontmatter has fields VS Code doesn't "
+            f"recognize: {sorted(unknown)}"
+        )
+
+    def test_frontmatter_has_no_claude_leaks(self, prompt_path: Path) -> None:
+        fm = _load_frontmatter(prompt_path)
+        leaks = set(fm) & FORBIDDEN_CLAUDE_FIELDS
+        assert not leaks, (
+            f"{prompt_path.name} frontmatter still contains Claude-specific fields: {sorted(leaks)}"
+        )
+
+    def test_agent_is_agent_mode(self, prompt_path: Path) -> None:
+        fm = _load_frontmatter(prompt_path)
+        assert fm.get("agent") == "agent", (
+            f"{prompt_path.name} should declare `agent: agent` so Copilot "
+            f"can auto-select tools; got {fm.get('agent')!r}"
+        )
+
+    def test_has_description(self, prompt_path: Path) -> None:
+        fm = _load_frontmatter(prompt_path)
+        assert fm.get("description"), f"{prompt_path.name} is missing description"
+
+    def test_no_dollar_arguments_leak(self, prompt_path: Path) -> None:
+        content = prompt_path.read_text(encoding="utf-8")
+        assert "$ARGUMENTS" not in content, (
+            f"{prompt_path.name} still contains Claude's $ARGUMENTS "
+            f"placeholder; Copilot uses ${{input:args}} instead."
+        )
+
+
+def test_every_command_has_a_matching_prompt() -> None:
+    """Each source command template has a regenerated prompt counterpart."""
+    commands = {p.stem for p in COMMANDS_DIR.glob("doit.*.md")}
+    prompts = {p.name.removesuffix(".prompt.md") for p in _collect_prompts()}
+    missing = commands - prompts
+    assert not missing, f"Missing .prompt.md for: {sorted(missing)}"
+
+
+def test_prompts_match_transformer_output() -> None:
+    """Shipped prompts equal what the current transformer would emit.
+
+    If this fails: the transformer changed but the .github/prompts/
+    directory wasn't regenerated. Run the transformer or invoke
+    `doit sync-prompts --agent copilot` and commit the result.
+    """
+    transformer = PromptTransformer()
+    mismatches: list[str] = []
+
+    for src in sorted(COMMANDS_DIR.glob("doit.*.md")):
+        template = CommandTemplate.from_path(src)
+        expected = transformer.transform(template)
+        dst = PROMPTS_DIR / f"{src.stem}.prompt.md"
+        if not dst.exists():
+            mismatches.append(f"{dst.name}: missing")
+            continue
+        actual = dst.read_text(encoding="utf-8")
+        if actual != expected:
+            mismatches.append(f"{dst.name}: out of sync with transformer output")
+
+    assert not mismatches, "\n".join(mismatches)
+
+
+def _load_frontmatter(path: Path) -> dict[str, object]:
+    content = path.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}
+    end = content.index("\n---", 3)
+    fm_text = content[3:end].strip()
+    parsed = yaml.safe_load(fm_text) or {}
+    assert isinstance(parsed, dict), f"frontmatter must be a YAML mapping in {path.name}"
+    return parsed

--- a/tests/integration/test_sync_prompts_command.py
+++ b/tests/integration/test_sync_prompts_command.py
@@ -129,13 +129,17 @@ class TestSyncPromptsCommand:
         assert output["total_commands"] == 1
 
     def test_sync_prompts_content_transformation(self, temp_dir):
-        """Test that content is properly transformed."""
-        # Setup with YAML frontmatter and $ARGUMENTS
+        """Verify the Copilot-native rewrite (Phase 6, April 2026)."""
         templates_dir = temp_dir / ".doit/templates/commands"
         templates_dir.mkdir(parents=True)
 
         template_content = """---
 description: Test description
+allowed-tools: Read, Write, Bash
+effort: high
+handoffs:
+  - label: Next
+    agent: doit.other
 ---
 
 ## User Input
@@ -154,14 +158,25 @@ $ARGUMENTS
         result = runner.invoke(app, ["sync-prompts", "--path", str(temp_dir)])
         assert result.exit_code == 0
 
-        # Verify transformation
         prompt_path = temp_dir / ".github/prompts/doit.test.prompt.md"
         prompt_content = prompt_path.read_text()
 
-        # YAML frontmatter should be stripped
-        assert "---\ndescription" not in prompt_content
-        # $ARGUMENTS should be replaced
+        # Copilot-native frontmatter present
+        assert prompt_content.startswith("---\n")
+        assert "description: Test description" in prompt_content
+        assert "agent: agent" in prompt_content
+        assert "editFiles" in prompt_content  # Read/Write -> editFiles
+        assert "runCommands" in prompt_content  # Bash -> runCommands
+
+        # Claude-specific fields scrubbed from frontmatter
+        frontmatter = prompt_content.split("---", 2)[1]
+        assert "allowed-tools" not in frontmatter
+        assert "handoffs" not in frontmatter
+        assert "effort" not in frontmatter
+
+        # Placeholder rewritten
         assert "$ARGUMENTS" not in prompt_content
+        assert "${input:args:" in prompt_content
         # Description should be preserved
         assert "Test description" in prompt_content
         # Outline should be preserved

--- a/tests/unit/test_error_recovery_patterns.py
+++ b/tests/unit/test_error_recovery_patterns.py
@@ -286,11 +286,24 @@ class TestSyncIntegrity:
 
     @pytest.mark.parametrize("command", ALL_COMMANDS)
     def test_github_prompts_match_source(self, command):
-        """MT-012: .github/prompts/ matches source templates"""
-        source = (TEMPLATES_DIR / command).read_text()
+        """MT-012: .github/prompts/ matches the transformer's output from source.
+
+        As of Phase 6 (April 2026), the sync does a semantic rewrite to
+        Copilot-native frontmatter rather than a byte-for-byte copy, so
+        equality with the raw source no longer holds. The invariant worth
+        checking is that the shipped prompt equals what the transformer
+        emits right now.
+        """
+        from doit_cli.models.sync_models import CommandTemplate
+        from doit_cli.services.prompt_transformer import PromptTransformer
+
         prompt_name = command.replace(".md", ".prompt.md")
         github_path = GITHUB_PROMPTS_DIR / prompt_name
         assert github_path.exists(), f".github/prompts/{prompt_name} missing"
-        assert source == github_path.read_text(), (
-            f".github/prompts/{prompt_name} differs from source"
+
+        template = CommandTemplate.from_path(TEMPLATES_DIR / command)
+        expected = PromptTransformer().transform(template)
+        assert github_path.read_text() == expected, (
+            f".github/prompts/{prompt_name} is out of sync with the "
+            f"transformer. Re-run `doit sync-prompts --agent copilot`."
         )

--- a/tests/unit/test_persona_aware_story_templates.py
+++ b/tests/unit/test_persona_aware_story_templates.py
@@ -287,9 +287,18 @@ class TestAgentSyncIntegrity:
         assert source == synced, "Claude commands specit differs from source template"
 
     def test_github_prompts_matches_source(self):
-        source = SPECIT_COMMAND.read_text()
+        """GitHub prompts are a Copilot-native rewrite of the source (see Phase 6).
+
+        Rather than a byte-for-byte equality check, assert the body instructions
+        made it through — frontmatter will differ by construction now.
+        """
         synced = GITHUB_SPECIT.read_text()
-        assert source == synced, "GitHub prompts specit differs from source template"
+        # Body content that exists in the source should exist in the rewrite
+        assert "## Persona Matching Rules (when personas loaded)" in synced
+        # Copilot-native frontmatter must be present
+        assert "agent: agent" in synced
+        # And Claude-specific leaks must not be
+        assert "allowed-tools" not in synced.split("---", 2)[1]
 
 
 class TestSpecitPersonaLoadingEnhanced:

--- a/tests/unit/test_sync_services.py
+++ b/tests/unit/test_sync_services.py
@@ -90,36 +90,26 @@ class TestTemplateReader:
 
 
 class TestPromptTransformer:
-    """Tests for PromptTransformer service."""
+    """Tests for the Copilot-native prompt transformer (April 2026 format).
 
-    def test_strip_yaml_frontmatter(self):
-        """Test YAML frontmatter is stripped."""
-        transformer = PromptTransformer()
-        content = "---\ndescription: Test\n---\n## Outline\nContent"
+    The transformer emits VS Code Copilot `.prompt.md` frontmatter
+    (`description`, `agent: agent`, `tools: [...]`) rather than stripping
+    frontmatter entirely. Previous tests asserted the strip-and-title
+    behaviour; those expectations have been replaced with ones that
+    check the new native-frontmatter contract.
+    """
 
-        result = transformer._strip_yaml_frontmatter(content)
-
-        assert "---" not in result
-        assert "description: Test" not in result
-        assert "## Outline" in result
-
-    def test_replace_arguments_placeholder(self):
-        """Test $ARGUMENTS placeholder is replaced."""
-        transformer = PromptTransformer()
-        content = "```text\n$ARGUMENTS\n```\nThen use $ARGUMENTS again."
-
-        result = transformer._replace_arguments_placeholder(content)
-
-        assert "$ARGUMENTS" not in result
-        assert "user" in result.lower()
-
-    def test_transform_full_template(self, temp_dir):
-        """Test full transformation of a template."""
+    def test_transform_emits_copilot_frontmatter(self, temp_dir):
         templates_dir = temp_dir / ".doit/templates/commands"
         templates_dir.mkdir(parents=True)
 
         template_content = """---
 description: Test command description
+allowed-tools: Read, Write, Edit, Bash
+effort: high
+handoffs:
+  - label: Follow up
+    agent: doit.other
 ---
 
 ## User Input
@@ -130,27 +120,76 @@ $ARGUMENTS
 
 ## Outline
 
-1. Do something
-2. Do something else
+Do something.
 """
         template_path = templates_dir / "doit.test.md"
         template_path.write_text(template_content)
 
         template = CommandTemplate.from_path(template_path)
-        transformer = PromptTransformer()
+        result = PromptTransformer().transform(template)
 
-        result = transformer.transform(template)
-
-        # Check frontmatter removed
-        assert "---\ndescription" not in result
-        # Check title added
-        assert "# Doit Test" in result
-        # Check description preserved
-        assert "Test command description" in result
-        # Check $ARGUMENTS replaced
-        assert "$ARGUMENTS" not in result
-        # Check outline preserved
+        assert result.startswith("---\n")
+        assert "description: Test command description" in result
+        assert "agent: agent" in result
+        assert "tools:" in result
+        # Claude-specific fields must not leak
+        assert "allowed-tools" not in result
+        assert "handoffs" not in result
+        assert "effort:" not in result
+        # Body preserved after frontmatter
         assert "## Outline" in result
+        assert "Do something." in result
+
+    def test_maps_claude_tools_to_copilot_tools(self, temp_dir):
+        templates_dir = temp_dir / ".doit/templates/commands"
+        templates_dir.mkdir(parents=True)
+        (templates_dir / "doit.t.md").write_text(
+            "---\ndescription: T\nallowed-tools: Read, Write, Glob, Grep\n---\n\nbody\n"
+        )
+        template = CommandTemplate.from_path(templates_dir / "doit.t.md")
+
+        result = PromptTransformer().transform(template)
+
+        assert "editFiles" in result  # Read/Write -> editFiles
+        assert "search" in result  # Glob/Grep -> search
+        assert "codebase" in result  # Glob/Grep -> codebase
+        # runCommands only appears if Bash was listed
+        assert "runCommands" not in result
+
+    def test_bash_tool_maps_to_run_commands(self, temp_dir):
+        templates_dir = temp_dir / ".doit/templates/commands"
+        templates_dir.mkdir(parents=True)
+        (templates_dir / "doit.b.md").write_text(
+            "---\ndescription: B\nallowed-tools: Bash\n---\n\nx\n"
+        )
+        template = CommandTemplate.from_path(templates_dir / "doit.b.md")
+        result = PromptTransformer().transform(template)
+        assert "runCommands" in result
+
+    def test_adds_github_repo_when_body_mentions_gh(self, temp_dir):
+        templates_dir = temp_dir / ".doit/templates/commands"
+        templates_dir.mkdir(parents=True)
+        (templates_dir / "doit.g.md").write_text(
+            "---\ndescription: G\nallowed-tools: Bash\n---\n\nUse `gh pr view` to read the PR.\n"
+        )
+        template = CommandTemplate.from_path(templates_dir / "doit.g.md")
+        result = PromptTransformer().transform(template)
+        assert "githubRepo" in result
+
+    def test_arguments_placeholder_becomes_copilot_input_variable(self, temp_dir):
+        templates_dir = temp_dir / ".doit/templates/commands"
+        templates_dir.mkdir(parents=True)
+        (templates_dir / "doit.a.md").write_text(
+            "---\ndescription: A\n---\n\n"
+            "## User Input\n\n```text\n$ARGUMENTS\n```\n\n"
+            "Later: $ARGUMENTS and positional $1.\n"
+        )
+        template = CommandTemplate.from_path(templates_dir / "doit.a.md")
+        result = PromptTransformer().transform(template)
+
+        assert "${input:args:" in result
+        assert "$ARGUMENTS" not in result
+        assert "${input:arg1}" in result
 
 
 class TestPromptWriter:

--- a/tests/unit/test_template_manager.py
+++ b/tests/unit/test_template_manager.py
@@ -396,21 +396,36 @@ class TestUnifiedTemplates:
             assert path.name.endswith(".prompt.md")
 
     def test_copilot_templates_are_transformed(self, temp_dir):
-        """Test Copilot templates have YAML frontmatter removed."""
+        """Test Copilot templates get Copilot-native frontmatter (April 2026).
+
+        Prior to Phase 6 the transformer stripped frontmatter entirely. The
+        current transformer rewrites it to Copilot's native schema
+        (agent: agent, tools: [...]) so `.prompt.md` files are still
+        wrapped in ---, just with different keys.
+        """
         manager = TemplateManager()
         target_dir = temp_dir / "copilot_output"
         target_dir.mkdir()
 
         manager.copy_templates_for_agent(Agent.COPILOT, target_dir)
 
-        # Check content of generated files
         for prompt_file in target_dir.iterdir():
-            if prompt_file.is_file():
-                content = prompt_file.read_text(encoding="utf-8")
-                # YAML frontmatter should be removed
-                assert not content.startswith("---")
-                # $ARGUMENTS should be replaced
-                assert "$ARGUMENTS" not in content
+            if not prompt_file.is_file():
+                continue
+            content = prompt_file.read_text(encoding="utf-8")
+
+            # Copilot-native frontmatter present
+            assert content.startswith("---")
+            assert "agent: agent" in content
+
+            # Claude-specific fields stripped
+            frontmatter = content.split("---", 2)[1]
+            assert "allowed-tools" not in frontmatter
+            assert "handoffs" not in frontmatter
+            assert "effort:" not in frontmatter
+
+            # Placeholder rewritten to Copilot input variable
+            assert "$ARGUMENTS" not in content
 
     def test_claude_templates_preserve_yaml(self, temp_dir):
         """Test Claude templates preserve YAML frontmatter."""


### PR DESCRIPTION
## Summary

Before this PR, the Copilot prompt transformer **stripped frontmatter entirely** and prepended a Title/description header. That was wrong for April 2026 VS Code Copilot, which expects its own native frontmatter schema ([docs](https://code.visualstudio.com/docs/copilot/customization/prompt-files)). As a separate bug, the shipped \`.github/prompts/*.prompt.md\` files never matched the transformer output — they carried raw Claude frontmatter (\`allowed-tools\`, \`effort\`, \`handoffs\`) and raw \`\$ARGUMENTS\` placeholders all the way through.

This PR rewrites the transformer, regenerates all 13 prompt files, and adds contract tests so the two can never diverge again.

## New frontmatter shape

\`\`\`yaml
---
description: <from source>
agent: agent
tools: [editFiles, search, codebase, runCommands, githubRepo?]
model: <from source, if set>
---
\`\`\`

**Dropped**: \`allowed-tools\`, \`handoffs\`, \`effort\` (none are VS Code-recognized). **\`githubRepo\`** is added heuristically when the body mentions the \`gh\` CLI.

## Tool mapping

| Claude tool | Copilot tool(s) |
|:------------|:----------------|
| \`Read\` / \`Write\` / \`Edit\` | \`editFiles\` |
| \`Glob\` / \`Grep\` | \`search\`, \`codebase\` |
| \`Bash\` | \`runCommands\` |
| body contains \`gh pr\`/\`gh issue\` | + \`githubRepo\` |

\`Bash(pattern)\` constraints are stripped — Copilot tools are named per-feature, not per-pattern.

## Placeholder rewrite

\`\`\`
\`\`\`text\n\$ARGUMENTS\n\`\`\`   ->  \${input:args:Describe …}
\$ARGUMENTS (inline)       ->  \${input:args}
\$0 / \$1 / \$N              ->  \${input:arg0} / \${input:arg1} / …
\`\`\`

## Contract tests (new)

\`tests/contract/test_copilot_prompt_format.py\` parameterizes across all 13 shipped prompts:

- Starts with \`---\`
- Frontmatter contains only VS Code-recognized fields
- No \`allowed-tools\`/\`handoffs\`/\`effort\` leaks
- \`agent: agent\` is set
- No \`\$ARGUMENTS\` leak
- Every source command has a matching prompt
- **Prompt content equals current transformer output** (fails loud if the source command is edited without re-running sync)

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,817** tests pass (1,759 prior + 78 new parameterized + 20 updated)
- [x] Existing tests that hard-coded the strip-frontmatter behaviour updated to the new contract
- [ ] CI green on Ubuntu / macOS / Windows
- [ ] Manual smoke: open one of the regenerated \`.prompt.md\` files in VS Code, confirm Copilot Chat accepts it without warnings

## Related

PR #788 (Phase 1, merged) · #789 (Phase 2, merged) · #791 (Phase 3, open) · #792 (Phase 4, open) · #793 (Phase 5a, open) · this PR (Phase 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)