### PR TITLE
docs: April 2026 modernization wrap-up (Phase 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,27 @@ doit sync-prompts              # Sync templates to AI agents
 - All `shutil.copy2` calls should use `TemplateManager._safe_copy()` to avoid SameFileError
 - Use `httpx` for API calls, never `requests`
 - Keep subprocess calls as list arguments (no `shell=True`)
+- **Error handling**: raise a subclass of `doit_cli.errors.DoitError` at boundaries; chain with `raise X(...) from e` inside `except` blocks (ruff B904 enforced)
+- **Exit codes**: every `typer.Exit(code=…)` call uses a `doit_cli.exit_codes.ExitCode` constant, never a numeric literal
+- **Output formats**: CLI commands that produce reports accept `--format/-f` declared via `doit_cli.cli.output.format_option()` with a per-command `allowed` subset
+- **Python modernity**: every `src/doit_cli/**/*.py` starts with `from __future__ import annotations`; type hints use `list[X] / X | None`, not `List/Optional`
 
 ## AI Integration
 
-- **Claude Code**: 12 slash commands in `.claude/commands/` (skills with frontmatter)
-- **GitHub Copilot**: 12 prompt files in `.github/prompts/`
-- **Workflow**: constitution -> roadmap -> spec -> plan -> tasks -> implement -> test -> review -> checkin
+Two template layouts ship side by side during the April 2026 Agent Skills transition:
+
+- **Claude Code (skills, current)**: 1 skill so far at `src/doit_cli/templates/skills/doit.constitution/SKILL.md`; the other 12 templates migrate in follow-ups (Phase 5b, 5c). Format documented in `docs/templates/agent-skills.md`.
+- **Claude Code (commands, legacy)**: 13 flat files in `src/doit_cli/templates/commands/doit.*.md`; still works per Anthropic's back-compat window. Synced to `.claude/commands/` by `doit sync-prompts`.
+- **GitHub Copilot**: 13 `.prompt.md` files in `.github/prompts/`, generated from the command sources by `PromptTransformer` (April 2026 Copilot schema: `agent: agent`, `tools: [...]`, `${input:args}` placeholders). Format documented in `docs/templates/copilot-prompts.md`.
+- **Workflow**: constitution → roadmap → researchit → specit → planit → taskit → implementit → testit → reviewit → fixit → documentit → scaffoldit → checkin
 
 ## Testing
 
-- 1749+ tests across unit, integration, contract, and E2E
+- 1,800+ tests across unit, integration, contract, and E2E
 - Platform-specific tests use markers: `@pytest.mark.windows`, `@pytest.mark.macos`
 - CI runs on push/PR to main and develop branches
+- Contract tests (`tests/contract/`) include a shipped-prompt validator that fails if `.github/prompts/` drifts from the transformer output — re-run `doit sync-prompts --agent copilot` if it fails
+- Run mypy manually (non-blocking during the type-hardening window): `pre-commit run mypy --hook-stage manual --all-files`
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->
@@ -96,6 +105,7 @@ doit sync-prompts              # Sync templates to AI agents
 - File-based — Markdown files in `.doit/memory/` and `specs/{feature}/` (057-persona-aware-user-story-generation)
 - N/A — Markdown template authoring only + None — no code changes (058-error-recovery-patterns)
 - File-based — Markdown templates in `.doit/templates/commands/` (058-error-recovery-patterns)
+- April 2026 modernization sweep: ruff + mypy + DoitError hierarchy + context_loader package split + ExitCode / OutputFormat CLI conventions + Agent Skills layout for Claude + native Copilot `.prompt.md` frontmatter
 
 ## Recent Changes
 - 055-mcp-server: Added Python 3.11+ (per constitution) + mcp (official MCP Python SDK with FastMCP), typer (CLI), rich (output)

--- a/docs/templates/agent-skills.md
+++ b/docs/templates/agent-skills.md
@@ -1,0 +1,104 @@
+# Agent Skills Format (April 2026)
+
+As of April 2026, doit's Claude Code templates follow the
+[Agent Skills open standard](https://agentskills.io). This page documents
+the format, where skills live, and how the legacy `.claude/commands/`
+layout continues to coexist during the deprecation window.
+
+## Two layouts, one workflow
+
+Anthropic merged custom slash commands into the Skills standard in early
+2026. Both of these produce the same `/skill-name` invocation:
+
+**Legacy: flat command file**
+```
+.claude/commands/doit.constitution.md
+```
+
+**Current: skill directory**
+```
+.claude/skills/doit.constitution/
+  SKILL.md           # required — playbook + frontmatter
+  reference.md       # optional — loaded on demand
+  examples/
+    sample.md
+```
+
+The skill layout wins when present. Both work today; new templates should
+ship as directories.
+
+## SKILL.md frontmatter
+
+Every skill directory has a `SKILL.md` file with YAML frontmatter. Fields
+doit uses:
+
+| Field | Required | Purpose |
+|:------|:---------|:--------|
+| `name` | yes | The `/skill-name` invocation and directory name (lowercase, hyphens allowed, ≤64 chars). |
+| `description` | yes | One-sentence summary Claude reads to decide when to load the skill. |
+| `when_to_use` | recommended | Trigger keywords / example phrases. Counts against the 1,536-char budget combined with `description`. |
+| `allowed-tools` | optional | Space-separated tool list. Constraints use `Bash(pattern)` form, e.g. `Bash(git add *) Bash(git commit *)`. |
+| `argument-hint` | optional | Hint shown in the `/` menu autocomplete, e.g. `[issue-number]`. |
+| `model` | optional | Override the session model. |
+| `disable-model-invocation` | optional | When `true`, only the user can invoke (not Claude). |
+| `user-invocable` | optional | When `false`, hides from the `/` menu (Claude-only). |
+
+Fields doit **deliberately does not emit** in the skill layout:
+
+- `effort` — default is to inherit from the session; hard-coding `high`
+  on every skill wastes tokens.
+- `handoffs` — not a native Claude Code field (doit-only invention). The
+  equivalent today is an inline "Next steps" section in the body that
+  suggests the next `/doit.<name>` invocation, or `context: fork` with
+  `agent:` for skills that truly need an isolated subagent.
+
+## Budgets
+
+Per [Anthropic's skill authoring guide](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) (April 2026):
+
+- **SKILL.md ≤ 500 lines.** Move long reference material into supporting
+  files and link to them with `See [reference.md](reference.md)`. Claude
+  loads referenced files on demand.
+- **`description` + `when_to_use` ≤ 1,536 characters combined.** Longer
+  text is truncated in Claude's skill listing, which can strip the
+  keywords Claude needs to match.
+
+`SkillTemplate.validate()` in `doit_cli.models.skill_template` enforces
+both budgets; the contract tests in `tests/contract/` run it against
+every shipped skill on every CI build.
+
+## Placeholder syntax
+
+SKILL.md still uses Claude's native placeholder syntax:
+
+- `$ARGUMENTS` — the full argument string typed after the skill name.
+- `$ARGUMENTS[N]` or `$N` — Nth positional argument, zero-indexed.
+- `${CLAUDE_SESSION_ID}`, `${CLAUDE_SKILL_DIR}` — session/path substitutions.
+
+The Copilot transformer (see [copilot-prompts.md](copilot-prompts.md))
+rewrites these to `${input:args:…}` when syncing to `.github/prompts/`.
+
+## Migration status
+
+As of April 2026, only the constitution template has been migrated to
+the skills layout. Templates still in the flat `.claude/commands/`
+format:
+
+- `doit.scaffoldit`, `doit.roadmapit`, `doit.researchit`, `doit.specit`,
+  `doit.planit`, `doit.taskit`, `doit.implementit`, `doit.reviewit`,
+  `doit.testit`, `doit.fixit`, `doit.documentit`, `doit.checkin`.
+
+Follow-up PRs (labelled Phase 5b, 5c in the modernization tracker)
+migrate the rest — oversized templates (specit, researchit, scaffoldit,
+documentit) will split into SKILL.md + supporting files to stay under
+the 500-line budget.
+
+## Where this lives in the package
+
+- Source: `src/doit_cli/templates/skills/<name>/SKILL.md`
+- Model:  [`doit_cli.models.skill_template.SkillTemplate`](../../src/doit_cli/models/skill_template.py)
+- Reader: [`doit_cli.services.skill_reader.SkillReader`](../../src/doit_cli/services/skill_reader.py)
+- Writer: [`doit_cli.services.skill_writer.SkillWriter`](../../src/doit_cli/services/skill_writer.py)
+
+The Copilot counterpart is documented in
+[copilot-prompts.md](copilot-prompts.md).

--- a/docs/templates/copilot-prompts.md
+++ b/docs/templates/copilot-prompts.md
@@ -1,0 +1,90 @@
+# GitHub Copilot Prompt Files (April 2026)
+
+doit generates GitHub Copilot slash-command prompts at
+`<project>/.github/prompts/doit.*.prompt.md`. Each is a semantic rewrite
+of the matching `src/doit_cli/templates/commands/doit.*.md` source file,
+not a byte-for-byte copy — doit translates between Claude's and VS Code
+Copilot's competing frontmatter schemas.
+
+## Frontmatter contract
+
+Per the [VS Code prompt files spec](https://code.visualstudio.com/docs/copilot/customization/prompt-files) (April 2026), each shipped
+`.prompt.md` emits:
+
+```yaml
+---
+description: <from source>
+agent: agent
+tools: [editFiles, search, codebase, runCommands, githubRepo?]
+model: <from source, if set>
+---
+```
+
+Fields emitted:
+
+| Field | Purpose |
+|:------|:--------|
+| `description` | Short summary shown in the `/` menu. Copied verbatim from the source Claude frontmatter. |
+| `agent` | Always `agent` — tells Copilot it may auto-select tools. Without this Copilot uses instructions only. |
+| `tools` | List of VS Code tool identifiers (see mapping below). Copilot restricts tool access to this set during the prompt. |
+| `model` | Passed through only if the source template set it; otherwise Copilot uses the picker default. |
+
+Fields deliberately **not** emitted (they'd trigger "unknown key" warnings
+in VS Code):
+
+- `allowed-tools` — Claude's field name; replaced by the mapped `tools:` list.
+- `handoffs` — doit-only invention.
+- `effort` — Claude session/skill level; no VS Code equivalent.
+- `argument-hint`, `when_to_use` — Claude skill-listing helpers.
+
+The contract test at `tests/contract/test_copilot_prompt_format.py`
+asserts these rules per-prompt on every CI build.
+
+## Tool mapping
+
+The transformer maps Claude's coarse-grained verbs to VS Code's
+per-feature tool identifiers:
+
+| Claude `allowed-tools` token | Copilot `tools` entry |
+|:-----------------------------|:----------------------|
+| `Read`, `Write`, `Edit` | `editFiles` |
+| `Glob`, `Grep` | `search`, `codebase` |
+| `Bash` | `runCommands` |
+| body text contains `gh pr`, `gh issue`, `gh api`, `gh auth` | **plus** `githubRepo` |
+
+`Bash(pattern)` constraints are stripped — Copilot tools are named per
+feature (`runCommands`) rather than per command, so per-pattern
+restriction doesn't translate. If tighter control is ever needed,
+VS Code's `chat.tools.autoApprove` setting is the escape hatch.
+
+## Placeholder rewrite
+
+Claude's SKILL.md placeholder syntax is rewritten to Copilot's
+`${input:…}` variables so Copilot prompts the user at invocation:
+
+| Source | Copilot |
+|:-------|:--------|
+| <code>\`\`\`text\n$ARGUMENTS\n\`\`\`</code> | `${input:args:Describe what you want to do for this command.}` |
+| Inline `$ARGUMENTS` | `${input:args}` |
+| `$0` / `$1` / `$N` | `${input:arg0}` / `${input:arg1}` / `${input:argN}` |
+
+## Where this lives in the package
+
+- Transformer: [`doit_cli.services.prompt_transformer.PromptTransformer`](../../src/doit_cli/services/prompt_transformer.py)
+- Writer: [`doit_cli.services.prompt_writer.PromptWriter`](../../src/doit_cli/services/prompt_writer.py)
+- CLI: `doit sync-prompts --agent copilot` regenerates every prompt from
+  the source commands.
+- Contract tests: [`tests/contract/test_copilot_prompt_format.py`](../../tests/contract/test_copilot_prompt_format.py)
+
+## Regenerating the prompts
+
+After editing any source template at
+`src/doit_cli/templates/commands/doit.*.md`, re-run:
+
+```bash
+doit sync-prompts --agent copilot
+```
+
+Commit the changes under `.github/prompts/` alongside the source edit.
+The contract test will fail CI if the two diverge — the failure message
+tells you to re-run sync.

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -1,7 +1,7 @@
 # Doit Template System Documentation
 
-**Version**: 1.0.0
-**Last Updated**: 2026-01-10
+**Version**: 1.1.0
+**Last Updated**: 2026-04-17
 
 ## Overview
 
@@ -77,18 +77,24 @@ flowchart TD
 | [checklist-template.md](root-templates.md#checklist-template) | Generic checklist format | Various checklist files |
 | [agent-file-template.md](root-templates.md#agent-file-template) | AI agent context file | `CLAUDE.md` |
 
-### Command Templates (9 files)
+### Command Templates (13 files)
+
+The `-it` suffix (April 2025+) replaced the earlier short names (e.g. `doit.specify` → `doit.specit`). Older documentation still referencing the short names predates this rename.
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
 | [doit.constitution](commands.md#doitconstitution) | Project principles & tech stack | Initialization |
-| [doit.scaffold](commands.md#doitscaffold) | Generate project structure | Initialization |
-| [doit.specify](commands.md#doitspecify) | Create feature specifications | Specification |
-| [doit.plan](commands.md#doitplan) | Generate implementation plan | Planning |
-| [doit.tasks](commands.md#doittasks) | Break down into tasks | Task Generation |
-| [doit.implement](commands.md#doitimplement) | Execute tasks | Implementation |
-| [doit.review](commands.md#doitreview) | Code review & manual testing | QA |
-| [doit.test](commands.md#doittest) | Automated test execution | QA |
+| [doit.scaffoldit](commands.md#doitscaffoldit) | Generate project structure | Initialization |
+| [doit.roadmapit](commands.md#doitroadmapit) | Prioritize and manage the roadmap | Initialization |
+| [doit.researchit](commands.md#doitresearchit) | Product-owner Q&A capture | Pre-spec |
+| [doit.specit](commands.md#doitspecit) | Create feature specifications | Specification |
+| [doit.planit](commands.md#doitplanit) | Generate implementation plan | Planning |
+| [doit.taskit](commands.md#doittaskit) | Break down into tasks | Task Generation |
+| [doit.implementit](commands.md#doitimplementit) | Execute tasks | Implementation |
+| [doit.reviewit](commands.md#doitreviewit) | Code review & manual testing | QA |
+| [doit.testit](commands.md#doittestit) | Automated test execution | QA |
+| [doit.fixit](commands.md#doitfixit) | Bug-fix workflow | Maintenance |
+| [doit.documentit](commands.md#doitdocumentit) | Documentation audit | Maintenance |
 | [doit.checkin](commands.md#doitcheckin) | Finalize & create PR | Completion |
 
 ## Artifact Flow


### PR DESCRIPTION
## Summary

Final docs pass closing out the seven-phase April 2026 modernization. **No code changes** — just documentation that reflects the new conventions landed in #788, #789, #791, #792, #793, #794.

## What's in this PR

- **\`docs/templates/index.md\`** — version + date refreshed; command table updated from the stale 9-command pre-rename list to the current 13 commands with correct \`-it\` suffixes (\`doit.specit\`, \`doit.planit\`, etc.).
- **\`docs/templates/agent-skills.md\`** (NEW) — the April 2026 Agent Skills directory layout. Frontmatter reference, budget rules (500-line SKILL.md / 1,536-char description budget), placeholder syntax, and links to the Python model/reader/writer.
- **\`docs/templates/copilot-prompts.md\`** (NEW) — the Phase 6 Copilot \`.prompt.md\` contract: Claude→VS Code tool mapping table, placeholder rewrites, regeneration workflow, and the contract test that fails CI on drift.
- **\`CLAUDE.md\`** — Code Conventions section picks up the new rules (\`DoitError\` hierarchy, \`ExitCode\` enum, \`format_option\`, \`from __future__ import annotations\` requirement). AI Integration section rewritten to describe the coexisting skills + legacy-commands + Copilot-prompts layouts. Testing section bumps the count and mentions the Copilot contract gate + manual mypy hook.

## Related (the full modernization chain)

1. #788 (merged) — Phase 1: ruff + mypy + future annotations
2. #789 (merged) — Phase 2: DoitError hierarchy + chained raises
3. #791 (open) — Phase 3: split \`context_loader\` into a package
4. #792 (open) — Phase 4: \`ExitCode\` + \`OutputFormat\` conventions
5. #793 (open) — Phase 5a: Agent Skills infra + constitution pilot
6. #794 (open) — Phase 6: Copilot-native \`.prompt.md\` transformer
7. **this PR** — Phase 7: docs refresh

## Test plan

- [x] \`ruff check src/ tests/ docs/\` clean
- [x] Full test suite passes on develop baseline (1,735 tests; the +78 contract checks from Phase 6 will apply once #794 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)