### PR TITLE
refactor(cli): migrate remaining commands onto ExitCode constants

### DIFF
--- a/src/doit_cli/cli/analytics_command.py
+++ b/src/doit_cli/cli/analytics_command.py
@@ -18,6 +18,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.status_models import SpecState
 from ..services.analytics_service import AnalyticsService
 from ..services.spec_scanner import NotADoitProjectError, SpecNotFoundError
@@ -71,7 +72,7 @@ def show(
                 print(json.dumps({"success": False, "error": "No specs found"}))
             else:
                 console.print("[yellow]No specifications found in specs/ directory.[/yellow]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         if json_output:
             report = service.generate_report()
@@ -79,14 +80,14 @@ def show(
         else:
             _print_completion_summary(summary)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         if json_output:
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 def _print_completion_summary(summary: dict) -> None:
@@ -163,7 +164,7 @@ def cycles(
                 filter_days = None  # since overrides days
             except ValueError:
                 console.print(f"[red]Error:[/red] Invalid date format '{since}'. Use YYYY-MM-DD.")
-                raise typer.Exit(code=2) from None
+                raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from None
 
         stats, records = service.get_cycle_time_stats(days=filter_days, since=since_date)
 
@@ -172,21 +173,21 @@ def cycles(
                 print(json.dumps({"success": False, "error": "No completed specs in period"}))
             else:
                 console.print("[yellow]No completed specs found in the specified period.[/yellow]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         if json_output:
             _print_cycles_json(stats, records)
         else:
             _print_cycles_tables(stats, records, days if not since else None, since)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         if json_output:
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 def _print_cycles_json(stats, records) -> None:
@@ -290,7 +291,7 @@ def velocity(
                 )
                 if velocity_data:
                     console.print(f"Available data points: {len(velocity_data)}")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         if format_type == "json":
             _print_velocity_json(velocity_data)
@@ -299,14 +300,14 @@ def velocity(
         else:
             _print_velocity_table(velocity_data, weeks)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         if format_type == "json":
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 def _print_velocity_json(velocity_data) -> None:
@@ -411,21 +412,21 @@ def spec(
                     console.print("\nAvailable specs:")
                     for a in available[:5]:
                         console.print(f"  - {a}")
-            raise typer.Exit(code=1) from None
+            raise typer.Exit(code=ExitCode.FAILURE) from None
 
         if json_output:
             _print_spec_json(metadata)
         else:
             _print_spec_details(metadata)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         if json_output:
             print(json.dumps({"success": False, "error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 def _print_spec_json(metadata) -> None:
@@ -544,14 +545,14 @@ def export(
         output_path.write_text(content, encoding="utf-8")
 
         console.print(f"[green]✓[/green] Analytics report exported to {output_path}")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
     except OSError as e:
         console.print(f"[red]Error:[/red] Failed to export report: {e}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 def _generate_markdown_report(report) -> str:

--- a/src/doit_cli/cli/constitution_command.py
+++ b/src/doit_cli/cli/constitution_command.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..services.cleanup_service import CleanupService
 
 app = typer.Typer(help="Constitution management commands")
@@ -78,14 +79,14 @@ def cleanup(
     if not memory_dir.exists():
         console.print(f"[red]Error:[/red] No .doit/memory directory found at {project_root}")
         console.print("Run [cyan]doit init[/cyan] to initialize the project first.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     service = CleanupService(project_root)
     constitution_path = service.constitution_path
 
     if not constitution_path.exists():
         console.print(f"[red]Error:[/red] Constitution not found at {constitution_path}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Analyze content first
     console.print(f"\n[bold]Analyzing[/bold] {constitution_path.relative_to(project_root)}...")
@@ -94,20 +95,20 @@ def cleanup(
     if not analysis.has_tech_content:
         console.print("\n[green]✓[/green] No tech-stack sections found in constitution.md")
         console.print("Constitution is already clean - no changes needed.")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     # Display what will be changed
     _display_analysis(analysis)
 
     if dry_run:
         console.print("\n[yellow]Dry run mode[/yellow] - no changes made.")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     # Check for existing tech-stack.md
     if service.tech_stack_path.exists() and not merge:
         console.print(f"\n[yellow]Warning:[/yellow] {service.tech_stack_path.name} already exists.")
         console.print("Use [cyan]--merge[/cyan] to combine content, or remove the existing file.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Confirm before proceeding
     if not yes:
@@ -115,7 +116,7 @@ def cleanup(
         confirmed = typer.confirm("Proceed with cleanup?", default=True)
         if not confirmed:
             console.print("[yellow]Cancelled.[/yellow]")
-            raise typer.Exit(code=0)
+            raise typer.Exit(code=ExitCode.SUCCESS)
 
     # Perform cleanup
     console.print("\n[bold]Performing cleanup...[/bold]")
@@ -123,7 +124,7 @@ def cleanup(
 
     if result.error_message:
         console.print(f"\n[red]Error:[/red] {result.error_message}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Display results
     _display_result(result, project_root)

--- a/src/doit_cli/cli/context_command.py
+++ b/src/doit_cli/cli/context_command.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.context_config import ContextConfig
 from ..services.context_loader import ContextLoader
 
@@ -73,7 +74,7 @@ def show_context(
         context = loader.load()
     except Exception as e:
         console.print(f"\n[red]Error loading context: {e}[/red]")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
     # Show command-specific info
     if command:
@@ -261,7 +262,7 @@ def audit_context(
         console.print(
             f"[red]Invalid format '{output_format}'. Use one of: {', '.join(valid_formats)}[/red]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Validate severity option
     valid_severities = ["critical", "major", "minor"]
@@ -269,7 +270,7 @@ def audit_context(
         console.print(
             f"[red]Invalid severity '{severity}'. Use one of: {', '.join(valid_severities)}[/red]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Create auditor
     auditor = ContextAuditor(templates_dir=templates_dir)
@@ -279,7 +280,7 @@ def audit_context(
         console.print(
             "[dim]Run this command from the repository root or specify --templates-dir[/dim]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     console.print(f"[bold]Auditing templates in:[/bold] {auditor.templates_dir}")
     console.print("")
@@ -313,6 +314,6 @@ def audit_context(
 
     if report.total_findings > 0:
         console.print(f"\n[dim]Total findings: {report.total_findings}[/dim]")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
     else:
         console.print("[green]✓ All templates pass audit[/green]")

--- a/src/doit_cli/cli/diagram_command.py
+++ b/src/doit_cli/cli/diagram_command.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.diagram_models import DiagramType
 from ..services.diagram_service import DiagramService
 
@@ -117,18 +118,18 @@ def generate_command(
         console.print(
             "[red]Error:[/red] No spec file found. Provide a path or run from a spec directory."
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     if not resolved_path.exists():
         console.print(f"[red]Error:[/red] File not found: {resolved_path}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Parse diagram types
     types = _parse_diagram_types(diagram_type)
     if not types and diagram_type != "all":
         console.print(f"[red]Error:[/red] Unknown diagram type: {diagram_type}")
         console.print("Valid types: user-journey, er-diagram, architecture, all")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     console.print(f"Generating diagrams for: [cyan]{resolved_path}[/cyan]")
     console.print()
@@ -144,7 +145,7 @@ def generate_command(
     # Handle errors
     if not result.success:
         console.print(f"[red]Error:[/red] {result.error}")
-        raise typer.Exit(code=2 if strict else 1)
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR if strict else ExitCode.FAILURE)
 
     # Display results table
     if result.diagrams:
@@ -198,7 +199,7 @@ def generate_command(
         console.print(
             "[yellow]No diagrams generated.[/yellow] Check that the spec has User Stories or Key Entities."
         )
-        raise typer.Exit(code=3)
+        raise typer.Exit(code=ExitCode.PROVIDER_ERROR)
 
 
 @app.command(name="validate")
@@ -229,11 +230,11 @@ def validate_command(
     resolved_path = _resolve_file_path(file)
     if not resolved_path:
         console.print("[red]Error:[/red] No file found to validate.")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
     if not resolved_path.exists():
         console.print(f"[red]Error:[/red] File not found: {resolved_path}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
     console.print(f"Validating diagrams in: [cyan]{resolved_path}[/cyan]")
     console.print()
@@ -246,7 +247,7 @@ def validate_command(
 
     if not matches:
         console.print("[yellow]No Mermaid diagrams found in file.[/yellow]")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     from ..services.mermaid_validator import MermaidValidator
 
@@ -303,10 +304,10 @@ def validate_command(
 
     if has_errors:
         console.print("\n[red]Validation failed.[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
     else:
         console.print("\n[green]All diagrams valid.[/green]")
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
 
 # Export the app for registration

--- a/src/doit_cli/cli/hooks_command.py
+++ b/src/doit_cli/cli/hooks_command.py
@@ -7,6 +7,7 @@ import sys
 import typer
 from rich.console import Console
 
+from ..exit_codes import ExitCode
 from ..services.hook_manager import HookManager
 from ..services.hook_validator import HookValidator
 
@@ -36,7 +37,7 @@ def install_hooks(
     if not manager.is_git_repo():
         console.print("[red]Error: Not a Git repository.[/red]")
         console.print("Run 'git init' first to initialize a Git repository.")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     try:
         installed, skipped = manager.install_hooks(backup=backup, force=force)
@@ -57,7 +58,7 @@ def install_hooks(
 
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 @hooks_app.command("uninstall")
@@ -88,7 +89,7 @@ def hooks_status() -> None:
 
     if not manager.is_git_repo():
         console.print("[red]Not a Git repository[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     installed = manager.get_installed_hooks()
 
@@ -149,7 +150,7 @@ def restore_hooks(
 
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 @hooks_app.command("validate")
@@ -161,7 +162,7 @@ def validate_hook(
     if hook_type not in valid_types:
         console.print(f"[red]Invalid hook type: {hook_type}[/red]")
         console.print(f"Valid types: {', '.join(valid_types)}")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     validator = HookValidator()
 

--- a/src/doit_cli/cli/init_command.py
+++ b/src/doit_cli/cli/init_command.py
@@ -11,6 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
+from ..exit_codes import ExitCode
 from ..models.agent import Agent
 from ..models.project import Project
 from ..models.results import InitResult
@@ -120,7 +121,7 @@ def map_workflow_responses(responses: dict) -> tuple[list[Agent], Path | None]:
     # Check confirmation
     if responses.get("confirm-path") == "no":
         console.print("[yellow]Initialization cancelled.[/yellow]")
-        raise typer.Exit(0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     # Parse agent selection
     agent_str = responses.get("select-agent", "claude")
@@ -548,7 +549,7 @@ def init_command(
             agents = parse_agent_string(agent)
         except typer.BadParameter as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1) from e
+            raise typer.Exit(code=ExitCode.FAILURE) from e
 
     # Non-interactive mode: bypass workflow entirely (FR-003, FR-008)
     if yes:
@@ -562,7 +563,7 @@ def init_command(
         )
         display_init_result(result, agents or result.project.agents or [Agent.CLAUDE])
         if not result.success:
-            raise typer.Exit(1)
+            raise typer.Exit(code=ExitCode.FAILURE)
         return
 
     # Interactive mode: use workflow engine (FR-001, FR-002, FR-005)
@@ -592,7 +593,7 @@ def init_command(
         responses = engine.run(workflow, initial_responses=initial_responses)
     except KeyboardInterrupt:
         # State is saved by workflow engine (FR-007)
-        raise typer.Exit(130) from None
+        raise typer.Exit(code=ExitCode.USER_CANCEL) from None
 
     # Map workflow responses to init parameters (FR-006)
     workflow_agents, template_source = map_workflow_responses(responses)
@@ -617,4 +618,4 @@ def init_command(
     display_init_result(result, final_agents or result.project.agents or [Agent.CLAUDE])
 
     if not result.success:
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)

--- a/src/doit_cli/cli/mcp_command.py
+++ b/src/doit_cli/cli/mcp_command.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typer
 from rich.console import Console
 
+from ..exit_codes import ExitCode
+
 app = typer.Typer(help="MCP server for AI assistant integration")
 console = Console()
 
@@ -34,7 +36,7 @@ def serve_command() -> None:
             "[red]Error: MCP dependencies not installed.[/red]\n"
             "Install with: pip install doit-toolkit-cli[mcp]"
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     try:
         from ..mcp.server import create_server
@@ -44,7 +46,7 @@ def serve_command() -> None:
     except ImportError as e:
         console.print(f"[red]Failed to import MCP dependencies: {e}[/red]")
         console.print("Install with: pip install doit-toolkit-cli[mcp]")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except Exception as e:
         console.print(f"[red]MCP server error: {e}[/red]")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e

--- a/src/doit_cli/cli/memory_command.py
+++ b/src/doit_cli/cli/memory_command.py
@@ -14,6 +14,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.search_models import QueryType, SourceFilter
 from ..services.memory_search import MemorySearchService
 
@@ -44,7 +45,7 @@ def get_project_root() -> Path:
             return parent
 
     console.print("[red]Error:[/red] Not in a doit project. Run 'doit init' to initialize.")
-    raise typer.Exit(1)
+    raise typer.Exit(code=ExitCode.FAILURE)
 
 
 @memory_app.command(name="search")
@@ -111,7 +112,7 @@ def search_command(
             f"[red]Error:[/red] Invalid query type '{query_type}'. "
             "Use: keyword, phrase, natural, regex"
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(code=ExitCode.FAILURE) from None
 
     # If regex flag is set, override query type
     if use_regex:
@@ -124,12 +125,12 @@ def search_command(
         console.print(
             f"[red]Error:[/red] Invalid source filter '{source}'. Use: all, governance, specs"
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(code=ExitCode.FAILURE) from None
 
     # Validate max results
     if not 1 <= max_results <= 100:
         console.print("[red]Error:[/red] Max results must be between 1 and 100")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Create service and search
     service = MemorySearchService(project_root, console)
@@ -146,7 +147,7 @@ def search_command(
         )
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(3) from e
+        raise typer.Exit(code=ExitCode.PROVIDER_ERROR) from e
 
     execution_time_ms = int((time.time() - start_time) * 1000)
 

--- a/src/doit_cli/cli/provider_command.py
+++ b/src/doit_cli/cli/provider_command.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.wizard_models import WizardCancelledError
 from ..services.config_backup_service import ConfigBackupService
 from ..services.provider_config import ProviderConfig
@@ -79,7 +80,7 @@ def configure_command(
         except ValueError:
             console.print(f"[red]Error: Unknown provider '{provider}'[/red]")
             console.print("Valid providers: github, azure_devops, gitlab")
-            raise typer.Exit(code=1) from None
+            raise typer.Exit(code=ExitCode.FAILURE) from None
 
     elif auto_detect or not provider:
         # Auto-detect from git remote
@@ -118,7 +119,7 @@ def configure_command(
 
             if choice not in provider_map:
                 console.print("[red]Invalid choice[/red]")
-                raise typer.Exit(code=1)
+                raise typer.Exit(code=ExitCode.FAILURE)
 
             config.provider = provider_map[choice]
             config.auto_detected = False
@@ -261,18 +262,18 @@ def wizard_command(
 
         if result.cancelled:
             console.print("\n[yellow]Wizard cancelled.[/yellow]")
-            raise typer.Exit(code=0)
+            raise typer.Exit(code=ExitCode.SUCCESS)
 
         if not result.success:
             console.print(f"\n[red]Configuration failed: {result.error_message}[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
     except WizardCancelledError:
         wizard.handle_cancellation()
         console.print("\n[yellow]Wizard cancelled.[/yellow]")
-        raise typer.Exit(code=0) from None
+        raise typer.Exit(code=ExitCode.SUCCESS) from None
 
     except KeyboardInterrupt:
         wizard.handle_cancellation()
         console.print("\n[yellow]Wizard interrupted.[/yellow]")
-        raise typer.Exit(code=130) from None
+        raise typer.Exit(code=ExitCode.USER_CANCEL) from None

--- a/src/doit_cli/cli/roadmapit_impl.py
+++ b/src/doit_cli/cli/roadmapit_impl.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.roadmap import RoadmapItem
 from ..models.sync_metadata import SyncMetadata
 from ..services.github_cache_service import CacheError, GitHubCacheService
@@ -87,7 +88,7 @@ def show(
 
     except Exception as e:
         console.print(f"[red]✗ Error: {e}[/red]")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 def _fetch_github_epics(refresh: bool):
@@ -394,7 +395,7 @@ def add(
         # Validate priority
         if priority not in ("P1", "P2", "P3", "P4"):
             console.print(f"[red]✗ Invalid priority: {priority}. Must be P1, P2, P3, or P4[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         console.print("\n[bold]Adding roadmap item:[/bold]")
         console.print(f"  Title: {item}")
@@ -438,12 +439,12 @@ def add(
                     )
                     console.print(f"  Title: {item}")
                     console.print(f"  Labels: epic, priority:{priority}")
-                    raise typer.Exit(code=1) from e
+                    raise typer.Exit(code=ExitCode.FAILURE) from e
 
                 except GitHubAPIError as e:
                     console.print(f"\n[yellow]⚠ GitHub API error: {e}[/yellow]")
                     console.print("[yellow]  Item not created on GitHub[/yellow]")
-                    raise typer.Exit(code=1) from e
+                    raise typer.Exit(code=ExitCode.FAILURE) from e
 
             else:
                 console.print(
@@ -460,7 +461,7 @@ def add(
 
     except Exception as e:
         console.print(f"[red]✗ Error: {e}[/red]")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 @app.command(name="sync-milestones")
@@ -527,16 +528,16 @@ def sync_milestones(
     except GitHubAuthError as e:
         console.print(f"\n[red]✗ GitHub Authentication Error:[/red] {e}")
         console.print("\n[dim]Run: gh auth login[/dim]")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except GitHubAPIError as e:
         console.print(f"\n[red]✗ GitHub API Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except FileNotFoundError as e:
         console.print(f"\n[red]✗ File Not Found:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except Exception as e:
         console.print(f"\n[red]✗ Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 if __name__ == "__main__":

--- a/src/doit_cli/cli/sync_prompts_command.py
+++ b/src/doit_cli/cli/sync_prompts_command.py
@@ -10,6 +10,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.agent import Agent
 from ..models.sync_models import FileOperation, OperationType, SyncResult
 from ..services.command_writer import CommandWriter
@@ -278,7 +279,7 @@ def sync_prompts_command(
         target_agents = parse_sync_agents(agent)
     except typer.BadParameter as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
     # Initialize services
     reader = TemplateReader(project_root=project_root)
@@ -298,7 +299,7 @@ def sync_prompts_command(
             console.print(json.dumps({"error": msg}))
         else:
             console.print(f"[red]Error:[/red] {msg}")
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     all_results = []
 
@@ -338,4 +339,4 @@ def sync_prompts_command(
 
     # Exit with appropriate code
     if not combined.success:
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)

--- a/src/doit_cli/cli/team_command.py
+++ b/src/doit_cli/cli/team_command.py
@@ -29,6 +29,8 @@ from doit_cli.services.team_service import (
     TeamService,
 )
 
+from ..exit_codes import ExitCode
+
 app = typer.Typer(help="Team collaboration commands")
 console = Console()
 
@@ -50,7 +52,7 @@ def _require_initialized(service: TeamService) -> None:
             "[red]Error:[/red] Team collaboration not initialized.\n"
             "Run [cyan]doit team init[/cyan] first."
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
 
 def _format_time_ago(dt: datetime | None) -> str:
@@ -138,7 +140,7 @@ def init_team(
         if e.errors:
             for error in e.errors:
                 console.print(f"  • {error}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 # =============================================================================
@@ -215,13 +217,13 @@ def add_member(
 
     except MemberAlreadyExistsError:
         console.print(f"[red]Error:[/red] Member already exists: {email}")
-        raise typer.Exit(code=2) from None
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from None
     except TeamConfigValidationError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except PermissionDeniedError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=3) from e
+        raise typer.Exit(code=ExitCode.PROVIDER_ERROR) from e
 
 
 @app.command("remove")
@@ -250,14 +252,14 @@ def remove_member(
     member = service.get_member(email)
     if not member:
         console.print(f"[red]Error:[/red] Member not found: {email}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     # Confirm unless forced
     if not force:
         confirm = typer.confirm(f"Remove {email} from team?")
         if not confirm:
             console.print("Cancelled.")
-            raise typer.Exit(code=0)
+            raise typer.Exit(code=ExitCode.SUCCESS)
 
     try:
         service.remove_member(email)
@@ -265,10 +267,10 @@ def remove_member(
 
     except TeamConfigValidationError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
     except PermissionDeniedError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=3) from e
+        raise typer.Exit(code=ExitCode.PROVIDER_ERROR) from e
 
 
 # =============================================================================
@@ -400,7 +402,7 @@ def sync_memory(
             console.print()
             console.print("Run [cyan]doit team sync --force[/cyan] to keep local versions,")
             console.print("or resolve manually and run [cyan]doit team sync[/cyan] again.")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         if result.success:
             console.print()
@@ -426,16 +428,16 @@ def sync_memory(
             console.print("  Last sync: [cyan]just now[/cyan]")
         else:
             console.print(f"[red]Error:[/red] {result.error_message}")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
     except NoRemoteError as e:
         console.print(f"[red]Error:[/red] {e}")
         console.print("Push your repository to a remote first.")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
     except NetworkError as e:
         console.print(f"[yellow]Warning:[/yellow] {e}")
         console.print("Changes saved locally. They will sync when connectivity returns.")
-        raise typer.Exit(code=1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
 
 # =============================================================================
@@ -610,7 +612,7 @@ def list_notifications(
             console.print(
                 "Valid types: memory_changed, conflict_detected, member_joined, permission_changed"
             )
-            raise typer.Exit(code=1) from None
+            raise typer.Exit(code=ExitCode.FAILURE) from None
 
     notifications = notif_service.get_notifications(
         unread_only=not all_notifications,
@@ -737,7 +739,7 @@ def clear_notifications(
         confirm = typer.confirm(f"Clear all {count} notifications?")
         if not confirm:
             console.print("Cancelled.")
-            raise typer.Exit(code=0)
+            raise typer.Exit(code=ExitCode.SUCCESS)
 
     cleared = notif_service.clear_all()
     console.print(f"[green]✓ Cleared {cleared} notification{'s' if cleared != 1 else ''}[/green]")
@@ -959,7 +961,7 @@ def show_conflict(
 
     if not conflict:
         console.print(f"[red]Error:[/red] Conflict not found: {conflict_id}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     console.print()
     console.print(f"[bold]Conflict:[/bold] {conflict.file_path}")
@@ -1060,7 +1062,7 @@ def resolve_conflict(
         console.print(
             "[red]Error:[/red] Specify exactly one resolution: --keep-local, --keep-remote, or --manual"
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     if keep_local:
         resolution = ConflictResolution.KEEP_LOCAL
@@ -1095,7 +1097,7 @@ def resolve_conflict(
 
     if not conflict:
         console.print(f"[red]Error:[/red] Conflict not found: {conflict_id}")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.FAILURE)
 
     try:
         resolved = conflict_service.resolve_conflict(conflict.id, resolution)
@@ -1108,7 +1110,7 @@ def resolve_conflict(
 
     except ConflictNotFoundError:
         console.print(f"[red]Error:[/red] Conflict not found: {conflict_id}")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=ExitCode.FAILURE) from None
 
 
 @conflict_app.command("clear")
@@ -1144,7 +1146,7 @@ def clear_conflicts(
         confirm = typer.confirm("Continue?")
         if not confirm:
             console.print("Cancelled.")
-            raise typer.Exit(code=0)
+            raise typer.Exit(code=ExitCode.SUCCESS)
 
     count = conflict_service.clear_active_conflicts()
     console.print(f"[green]✓ Cleared {count} conflict(s)[/green]")
@@ -1207,7 +1209,7 @@ def team_config(
         access_service = AccessService()
         if not access_service.check_manage_permission():
             console.print("[red]Error:[/red] Only team owners can modify settings.")
-            raise typer.Exit(code=3)
+            raise typer.Exit(code=ExitCode.PROVIDER_ERROR)
 
         config = service.config
 
@@ -1219,7 +1221,7 @@ def team_config(
             if conflict_strategy not in ["prompt", "keep-local", "keep-remote"]:
                 console.print(f"[red]Error:[/red] Invalid conflict strategy: {conflict_strategy}")
                 console.print("Valid options: prompt, keep-local, keep-remote")
-                raise typer.Exit(code=1)
+                raise typer.Exit(code=ExitCode.FAILURE)
             config.sync.conflict_strategy = conflict_strategy
 
         service._save_config()

--- a/src/doit_cli/cli/update_command.py
+++ b/src/doit_cli/cli/update_command.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from ..exit_codes import ExitCode
 from ..models.agent import Agent
 from .init_command import display_init_result, parse_agent_string, run_init
 
@@ -47,7 +48,7 @@ def update_command(
             agents = parse_agent_string(agent)
         except typer.BadParameter as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1) from e
+            raise typer.Exit(code=ExitCode.FAILURE) from e
 
     result = run_init(
         path=path,
@@ -58,4 +59,4 @@ def update_command(
     )
     display_init_result(result, agents or result.project.agents or [Agent.CLAUDE])
     if not result.success:
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)

--- a/src/doit_cli/cli/validate_command.py
+++ b/src/doit_cli/cli/validate_command.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from ..exit_codes import ExitCode
 from ..models.validation_models import ValidationConfig
 from ..services.report_generator import ReportGenerator
 from ..services.validation_service import ValidationService
@@ -78,7 +79,7 @@ def validate_command(
                     print('{"error": "No spec files found in specs/ directory"}')
                 else:
                     console.print("[yellow]No spec files found in specs/ directory[/yellow]")
-                raise typer.Exit(1)
+                raise typer.Exit(code=ExitCode.FAILURE)
 
             summary = service.get_summary(results)
 
@@ -96,7 +97,7 @@ def validate_command(
 
             # Exit with error if any specs failed
             if summary["failed"] > 0:
-                raise typer.Exit(1)
+                raise typer.Exit(code=ExitCode.FAILURE)
 
         elif target_path.is_file():
             # Validate single file
@@ -105,7 +106,7 @@ def validate_command(
                     print('{"error": "Not a markdown file"}')
                 else:
                     console.print(f"[red]Error:[/red] Not a markdown file: {target_path}")
-                raise typer.Exit(1)
+                raise typer.Exit(code=ExitCode.FAILURE)
 
             result = service.validate_file(target_path)
 
@@ -116,7 +117,7 @@ def validate_command(
 
             # Exit with error if validation failed
             if result.error_count > 0:
-                raise typer.Exit(1)
+                raise typer.Exit(code=ExitCode.FAILURE)
 
         elif target_path.is_dir():
             # Check if this is a spec directory (contains spec.md)
@@ -132,7 +133,7 @@ def validate_command(
                     reporter.display_result(result)
 
                 if result.error_count > 0:
-                    raise typer.Exit(1)
+                    raise typer.Exit(code=ExitCode.FAILURE)
             else:
                 # Validate all specs in the directory
                 results = service.validate_directory(target_path)
@@ -142,7 +143,7 @@ def validate_command(
                         print('{"error": "No spec files found in directory"}')
                     else:
                         console.print(f"[yellow]No spec files found in {target_path}[/yellow]")
-                    raise typer.Exit(1)
+                    raise typer.Exit(code=ExitCode.FAILURE)
 
                 summary = service.get_summary(results)
 
@@ -157,25 +158,25 @@ def validate_command(
                     reporter.display_summary(results, summary)
 
                 if summary["failed"] > 0:
-                    raise typer.Exit(1)
+                    raise typer.Exit(code=ExitCode.FAILURE)
 
         else:
             if json_output:
                 print(f'{{"error": "Path not found: {target_path}"}}')
             else:
                 console.print(f"[red]Error:[/red] Path not found: {target_path}")
-            raise typer.Exit(1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
     except FileNotFoundError as e:
         if json_output:
             print(f'{{"error": "{e}"}}')
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e
 
     except ValueError as e:
         if json_output:
             print(f'{{"error": "{e}"}}')
         else:
             console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1) from e
+        raise typer.Exit(code=ExitCode.FAILURE) from e

--- a/src/doit_cli/cli/verify_command.py
+++ b/src/doit_cli/cli/verify_command.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.agent import Agent
 from ..models.project import Project
 from ..models.results import VerifyResult, VerifyStatus
@@ -172,7 +173,7 @@ def verify_command(
                 console.print(json.dumps({"error": str(e)}))
             else:
                 console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(1) from e
+            raise typer.Exit(code=ExitCode.FAILURE) from e
 
     # Create project and validator
     project = Project(path=path.resolve())
@@ -189,4 +190,4 @@ def verify_command(
 
     # Exit with appropriate code
     if not result.passed:
-        raise typer.Exit(1)
+        raise typer.Exit(code=ExitCode.FAILURE)

--- a/src/doit_cli/cli/xref_command.py
+++ b/src/doit_cli/cli/xref_command.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..exit_codes import ExitCode
 from ..models.crossref_models import CoverageReport, CoverageStatus
 from ..services.crossref_service import CrossReferenceService
 from ..services.spec_scanner import NotADoitProjectError
@@ -183,7 +184,7 @@ def coverage_command(
                     "[red]Error:[/red] Could not detect spec. "
                     "Please provide spec name or run from a feature branch."
                 )
-                raise typer.Exit(code=2)
+                raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate format
         valid_formats = ["rich", "json", "markdown"]
@@ -192,7 +193,7 @@ def coverage_command(
                 f"[red]Error:[/red] Invalid format '{output_format}'. "
                 f"Valid: {', '.join(valid_formats)}"
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Get coverage report
         service = CrossReferenceService()
@@ -200,7 +201,7 @@ def coverage_command(
             report = service.get_coverage(spec_name=spec_name)
         except FileNotFoundError as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2) from e
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
         # Format output
         if output_format == "json":
@@ -227,15 +228,15 @@ def coverage_command(
         has_uncovered = report.uncovered_count > 0
 
         if has_orphaned:
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
         if strict and has_uncovered:
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 @xref_app.command(name="locate")
@@ -263,7 +264,7 @@ def locate_command(
                 "[red]Error:[/red] Could not detect spec. "
                 "Please provide --spec or run from a feature branch."
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate format
         valid_formats = ["rich", "json", "line"]
@@ -272,7 +273,7 @@ def locate_command(
                 f"[red]Error:[/red] Invalid format '{output_format}'. "
                 f"Valid: {', '.join(valid_formats)}"
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Find requirement
         service = CrossReferenceService()
@@ -280,11 +281,11 @@ def locate_command(
             req = service.locate_requirement(requirement_id, spec_name=spec_name)
         except (FileNotFoundError, ValueError) as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2) from e
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
         if req is None:
             console.print(f"[yellow]Requirement {requirement_id} not found in spec.[/yellow]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         # Format output
         if output_format == "json":
@@ -303,11 +304,11 @@ def locate_command(
             console.print(f"[cyan]{req.id}[/cyan]: {req.description}")
             console.print(f"Location: [dim]{req.spec_path}:{req.line_number}[/dim]")
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 @xref_app.command(name="tasks")
@@ -333,7 +334,7 @@ def tasks_command(
                 "[red]Error:[/red] Could not detect spec. "
                 "Please provide --spec or run from a feature branch."
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate format
         valid_formats = ["rich", "json", "markdown"]
@@ -342,7 +343,7 @@ def tasks_command(
                 f"[red]Error:[/red] Invalid format '{output_format}'. "
                 f"Valid: {', '.join(valid_formats)}"
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Get tasks
         service = CrossReferenceService()
@@ -350,11 +351,11 @@ def tasks_command(
             tasks = service.get_tasks_for_requirement(requirement_id, spec_name=spec_name)
         except (FileNotFoundError, ValueError) as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2) from e
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
         if not tasks:
             console.print(f"[yellow]No tasks found implementing {requirement_id}[/yellow]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
         # Format output
         if output_format == "json":
@@ -411,11 +412,11 @@ def tasks_command(
                 f"\nFound {len(tasks)} tasks ({completed} complete, {len(tasks) - completed} pending)"
             )
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
 
 @xref_app.command(name="validate")
@@ -446,7 +447,7 @@ def validate_command(
                     "[red]Error:[/red] Could not detect spec. "
                     "Please provide spec name or run from a feature branch."
                 )
-                raise typer.Exit(code=2)
+                raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate format
         valid_formats = ["rich", "json"]
@@ -455,7 +456,7 @@ def validate_command(
                 f"[red]Error:[/red] Invalid format '{output_format}'. "
                 f"Valid: {', '.join(valid_formats)}"
             )
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate references
         service = CrossReferenceService()
@@ -464,7 +465,7 @@ def validate_command(
             report = service.get_coverage(spec_name=spec_name)
         except FileNotFoundError as e:
             console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=2) from e
+            raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
         # Count issues
         error_count = len(orphaned)  # Orphaned references are always errors
@@ -530,10 +531,10 @@ def validate_command(
 
         # Determine exit code
         if error_count > 0:
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=ExitCode.FAILURE)
 
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=ExitCode.SUCCESS)
 
     except NotADoitProjectError as e:
         console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=2) from e
+        raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e

--- a/tests/contract/test_cli_exit_codes.py
+++ b/tests/contract/test_cli_exit_codes.py
@@ -1,0 +1,39 @@
+"""Contract: every CLI command uses ExitCode constants, never numeric literals.
+
+Numeric `typer.Exit(code=N)` calls obscure intent and make the CLI
+contract hard to reason about across versions. Every new or edited
+command must pull codes from `doit_cli.exit_codes.ExitCode` instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+CLI_DIR = Path(__file__).resolve().parents[2] / "src" / "doit_cli" / "cli"
+
+# Matches typer.Exit(code=N) or typer.Exit(N) where N is a literal.
+# Allows the ternary form: typer.Exit(code=ExitCode.X if cond else ExitCode.Y)
+# by anchoring on an integer right after the paren.
+NUMERIC_EXIT_PATTERN = re.compile(
+    r"typer\.Exit\s*\(\s*(?:code\s*=\s*)?(\d+)\b"
+)
+
+
+def test_no_numeric_typer_exit_in_cli() -> None:
+    violations: list[str] = []
+
+    for py in sorted(CLI_DIR.glob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            match = NUMERIC_EXIT_PATTERN.search(line)
+            if match:
+                violations.append(
+                    f"{py.name}:{lineno}: uses numeric exit code "
+                    f"{match.group(1)} — use ExitCode.X instead"
+                )
+
+    assert not violations, (
+        "CLI files must use doit_cli.exit_codes.ExitCode constants:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

Phase 4 (#792) introduced the \`ExitCode\` IntEnum + pilot migrations on \`status\` and \`fixit\`. This PR finishes the job: every remaining CLI file uses \`ExitCode\` constants instead of numeric literals, and a contract test locks the convention.

**Stacked on #792.** Base retargets to \`develop\` automatically once Phase 4 merges.

## What changed

**135 sites migrated** across 16 command files. Both \`typer.Exit(code=N)\` and the positional \`typer.Exit(N)\` form are handled.

Mapping used:
- \`code=0\` → \`ExitCode.SUCCESS\`
- \`code=1\` → \`ExitCode.FAILURE\`
- \`code=2\` → \`ExitCode.VALIDATION_ERROR\`
- \`code=3\` → \`ExitCode.PROVIDER_ERROR\` (team/auth/provider errors)
- \`code=130\` → \`ExitCode.USER_CANCEL\` (Ctrl+C / SIGINT convention)

**New contract test** (\`tests/contract/test_cli_exit_codes.py\`) greps every \`src/doit_cli/cli/*.py\` for \`typer.Exit(N)\` or \`typer.Exit(code=N)\` with a numeric literal. Fails with a clear message pointing at the offending file:line if a new command tries to regress the convention.

## What this PR deliberately does **not** do

- **\`--format\` option migration** — each command carries its own allowed set (e.g. \`fixit\` = {table, json}; \`status\` = {rich, json, markdown}; \`analytics export\` = {markdown, json}). That's a semantic change per command, not a global substitution. Follow-up PR per command.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,750** tests pass (1,749 prior + 1 new contract test)
- [x] CLI smoke: \`doit --help\`, \`doit status\` render unchanged
- [ ] CI green on Ubuntu / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)