### PR TITLE
feat(skills): migrate 8 simple templates to Agent Skills layout (Phase 5b)

### DIFF
--- a/src/doit_cli/models/skill_template.py
+++ b/src/doit_cli/models/skill_template.py
@@ -1,0 +1,211 @@
+"""Data model for Agent Skills directory-based templates.
+
+The Agent Skills standard (https://agentskills.io) represents a skill as a
+**directory** containing a required `SKILL.md` plus optional supporting files.
+This module parses such a directory into a `SkillTemplate` instance.
+
+This model is parallel to `CommandTemplate` (which represents a single flat
+`.md` file in the legacy `.claude/commands/` layout). Both formats are
+supported during the deprecation window so users can migrate at their own
+pace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is a hard dependency
+    yaml = None  # type: ignore[assignment]
+
+
+SKILL_ENTRYPOINT = "SKILL.md"
+
+# Fields we enforce presence / shape on. Everything else is passed through.
+REQUIRED_FRONTMATTER = ("name", "description")
+
+# Per the April 2026 Claude Code docs, the combined description + when_to_use
+# is truncated at this many characters in the skill listing.
+DESCRIPTION_CHAR_BUDGET = 1_536
+
+# Per Anthropic guidance, keep SKILL.md under this many lines. Supporting
+# files absorb the overflow and are loaded on demand by Claude.
+SKILL_MAX_LINES = 500
+
+
+@dataclass
+class SkillTemplate:
+    """A parsed Agent-Skills-format skill directory.
+
+    Use `SkillTemplate.from_directory(path)` to parse a skill on disk; the
+    frontmatter is exposed via the typed attributes below and the full list
+    of files (including supporting files like `examples/` or `reference.md`)
+    is available via `supporting_files`.
+    """
+
+    name: str
+    """Skill name (also the directory name). Becomes `/skill-name` at runtime."""
+
+    directory: Path
+    """Absolute path to the skill directory."""
+
+    description: str
+    """One-sentence summary of what the skill does."""
+
+    modified_at: datetime
+    """Last-modified timestamp of SKILL.md."""
+
+    when_to_use: str = ""
+    """Optional trigger keywords / example phrases."""
+
+    allowed_tools: str = ""
+    """Tool permission string (space-separated per Anthropic docs, or comma-
+    separated — we preserve the user's form rather than re-normalizing)."""
+
+    argument_hint: str = ""
+    """Hint shown in the / menu autocomplete (e.g. `[issue-number]`)."""
+
+    model: str = ""
+    """Override model for this skill. Empty means inherit from session."""
+
+    disable_model_invocation: bool = False
+    """When True, only the user can invoke via `/name`."""
+
+    user_invocable: bool = True
+    """When False, hides from the / menu (Claude-only)."""
+
+    frontmatter: dict[str, Any] = field(default_factory=dict, repr=False)
+    """Full parsed frontmatter, including fields not modeled above."""
+
+    body: str = field(default="", repr=False)
+    """The SKILL.md content following the frontmatter block."""
+
+    supporting_files: list[Path] = field(default_factory=list, repr=False)
+    """All other files in the skill directory, as absolute paths."""
+
+    # -- lifecycle --------------------------------------------------------
+
+    @classmethod
+    def from_directory(cls, directory: Path) -> SkillTemplate:
+        """Parse a skill directory into a SkillTemplate.
+
+        Raises:
+            FileNotFoundError: the directory or SKILL.md is missing.
+            ValueError: SKILL.md has no closing frontmatter delimiter or
+                is missing required fields.
+        """
+        if not directory.is_dir():
+            raise FileNotFoundError(f"Skill directory not found: {directory}")
+
+        skill_md = directory / SKILL_ENTRYPOINT
+        if not skill_md.is_file():
+            raise FileNotFoundError(
+                f"Skill is missing {SKILL_ENTRYPOINT}: {directory}"
+            )
+
+        raw = skill_md.read_text(encoding="utf-8")
+        fm, body = _split_frontmatter(raw)
+        modified_at = datetime.fromtimestamp(skill_md.stat().st_mtime)
+
+        for field_name in REQUIRED_FRONTMATTER:
+            if field_name not in fm:
+                raise ValueError(
+                    f"Skill {directory.name}/{SKILL_ENTRYPOINT} is missing "
+                    f"required frontmatter key '{field_name}'."
+                )
+
+        supporting = sorted(
+            p
+            for p in directory.rglob("*")
+            if p.is_file() and p.resolve() != skill_md.resolve()
+        )
+
+        return cls(
+            name=str(fm["name"]),
+            directory=directory,
+            description=str(fm["description"]),
+            when_to_use=str(fm.get("when_to_use", "")),
+            allowed_tools=_flatten(fm.get("allowed-tools", "")),
+            argument_hint=str(fm.get("argument-hint", "")),
+            model=str(fm.get("model", "")),
+            disable_model_invocation=bool(fm.get("disable-model-invocation", False)),
+            user_invocable=bool(fm.get("user-invocable", True)),
+            frontmatter=fm,
+            body=body,
+            supporting_files=supporting,
+            modified_at=modified_at,
+        )
+
+    # -- validation -------------------------------------------------------
+
+    @property
+    def description_char_count(self) -> int:
+        """Combined description + when_to_use length used by Claude's skill listing."""
+        return len(self.description) + len(self.when_to_use)
+
+    @property
+    def skill_md_line_count(self) -> int:
+        """Line count of SKILL.md — keep under SKILL_MAX_LINES per April 2026 guidance."""
+        return self.body.count("\n") + 1
+
+    def validate(self) -> list[str]:
+        """Return a list of human-readable warnings. Empty list = clean.
+
+        Checks enforced here mirror the constraints documented by Anthropic
+        in https://code.claude.com/docs/en/skills as of April 2026.
+        """
+        issues: list[str] = []
+        if self.description_char_count > DESCRIPTION_CHAR_BUDGET:
+            issues.append(
+                f"{self.name}: combined description+when_to_use is "
+                f"{self.description_char_count} chars (budget is "
+                f"{DESCRIPTION_CHAR_BUDGET} before Claude truncates)."
+            )
+        if self.skill_md_line_count > SKILL_MAX_LINES:
+            issues.append(
+                f"{self.name}: SKILL.md is {self.skill_md_line_count} lines "
+                f"(target is <= {SKILL_MAX_LINES}; move detail into "
+                f"supporting files)."
+            )
+        if len(self.name) > 64:
+            issues.append(f"{self.name}: name exceeds 64-char limit.")
+        return issues
+
+
+# --------------------------------------------------------------------------
+# helpers
+
+
+def _flatten(value: Any) -> str:
+    """Render an allowed-tools value as a string regardless of list vs string form."""
+    if isinstance(value, list):
+        return " ".join(str(v) for v in value)
+    return str(value)
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, Any], str]:
+    """Split YAML frontmatter from the body. Returns ({}, raw) when no frontmatter."""
+    if not raw.startswith("---"):
+        return {}, raw
+
+    try:
+        end = raw.index("\n---", 3)
+    except ValueError as exc:
+        raise ValueError("SKILL.md has opening '---' but no closing delimiter.") from exc
+
+    fm_text = raw[3:end].strip()
+    body = raw[end + len("\n---") :].lstrip("\n")
+
+    if yaml is None:  # pragma: no cover
+        raise RuntimeError(
+            "pyyaml is required to parse SKILL.md frontmatter but is not installed."
+        )
+
+    parsed = yaml.safe_load(fm_text) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError("SKILL.md frontmatter must be a YAML mapping.")
+    return parsed, body

--- a/src/doit_cli/services/skill_reader.py
+++ b/src/doit_cli/services/skill_reader.py
@@ -1,0 +1,73 @@
+"""Discover Agent-Skills-format skill directories bundled with the package.
+
+`SkillReader.scan_bundled_skills()` returns one `SkillTemplate` per skill
+found under `src/doit_cli/templates/skills/`. Both the top-level skill
+directories and their supporting files are discovered here; writing them
+to a project belongs to `SkillWriter`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..models.skill_template import SKILL_ENTRYPOINT, SkillTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class SkillReader:
+    """Scans the bundled skills directory."""
+
+    BUNDLED_RELATIVE_PATH = Path("templates") / "skills"
+
+    def __init__(self, package_root: Path | None = None) -> None:
+        """Initialize the reader.
+
+        Args:
+            package_root: Path to the `src/doit_cli/` package dir. Defaults
+                to the directory containing the `doit_cli` package.
+        """
+        if package_root is None:
+            # Walk up from this file: services/skill_reader.py -> services -> doit_cli
+            package_root = Path(__file__).resolve().parent.parent
+        self.package_root = package_root
+        self.skills_root = package_root / self.BUNDLED_RELATIVE_PATH
+
+    def scan_bundled_skills(self) -> list[SkillTemplate]:
+        """Return every valid skill under the bundled skills root.
+
+        A valid skill is any immediate child directory of `skills_root`
+        whose name does not begin with `_` (reserved for `_shared/` etc.)
+        and which contains a `SKILL.md` file.
+
+        Invalid directories are logged and skipped, not raised — this lets
+        the CLI keep working if one template has a parse error while we're
+        editing it.
+        """
+        if not self.skills_root.is_dir():
+            logger.debug("skills root does not exist: %s", self.skills_root)
+            return []
+
+        skills: list[SkillTemplate] = []
+        for child in sorted(self.skills_root.iterdir()):
+            if not child.is_dir():
+                continue
+            if child.name.startswith("_"):
+                continue
+            if not (child / SKILL_ENTRYPOINT).is_file():
+                logger.debug("skipping %s (no %s)", child, SKILL_ENTRYPOINT)
+                continue
+            try:
+                skills.append(SkillTemplate.from_directory(child))
+            except (OSError, ValueError) as exc:
+                logger.warning("failed to parse skill %s: %s", child, exc)
+
+        return skills
+
+    def get_skill(self, name: str) -> SkillTemplate | None:
+        """Return the skill with the given name, or None if not found."""
+        for skill in self.scan_bundled_skills():
+            if skill.name == name:
+                return skill
+        return None

--- a/src/doit_cli/services/skill_writer.py
+++ b/src/doit_cli/services/skill_writer.py
@@ -1,0 +1,89 @@
+"""Write Agent-Skills-format skill directories to a target project.
+
+Mirrors `CommandWriter`'s safe-copy pattern but at the directory level —
+each skill becomes `<project>/.claude/skills/<name>/` with SKILL.md and
+any supporting files copied verbatim.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..models.skill_template import SkillTemplate
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SkillWriteResult:
+    """Outcome of writing a single skill."""
+
+    skill_name: str
+    target_dir: Path
+    files_written: list[Path]
+    was_overwrite: bool
+
+
+class SkillWriter:
+    """Writes bundled skills into a project's `.claude/skills/` directory."""
+
+    DEFAULT_SKILLS_DIR = ".claude/skills"
+
+    def __init__(self, project_root: Path | None = None) -> None:
+        self.project_root = project_root or Path.cwd()
+        self.skills_dir = self.project_root / self.DEFAULT_SKILLS_DIR
+
+    def write_skill(self, skill: SkillTemplate, *, overwrite: bool = True) -> SkillWriteResult:
+        """Copy a skill directory into the target project.
+
+        Args:
+            skill: Parsed SkillTemplate from the bundled source.
+            overwrite: When False, raises FileExistsError if the target
+                directory already exists. When True (default), the target
+                is replaced atomically — existing user edits are lost,
+                consistent with `.claude/commands/` behavior.
+        """
+        target_dir = self.skills_dir / skill.directory.name
+        was_overwrite = target_dir.exists()
+
+        if was_overwrite and not overwrite:
+            raise FileExistsError(f"Skill already exists at {target_dir}")
+
+        if was_overwrite:
+            shutil.rmtree(target_dir)
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        files_written: list[Path] = []
+
+        # Copy SKILL.md first so the entrypoint exists even if supporting
+        # files fail partway.
+        src_skill_md = skill.directory / "SKILL.md"
+        dst_skill_md = target_dir / "SKILL.md"
+        shutil.copy2(src_skill_md, dst_skill_md)
+        files_written.append(dst_skill_md)
+
+        for source in skill.supporting_files:
+            rel = source.relative_to(skill.directory)
+            dst = target_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, dst)
+            files_written.append(dst)
+
+        logger.debug("wrote skill %s to %s (%d files)", skill.name, target_dir, len(files_written))
+        return SkillWriteResult(
+            skill_name=skill.name,
+            target_dir=target_dir,
+            files_written=files_written,
+            was_overwrite=was_overwrite,
+        )
+
+    def write_all(
+        self, skills: list[SkillTemplate], *, overwrite: bool = True
+    ) -> list[SkillWriteResult]:
+        """Write multiple skills, returning per-skill results."""
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        return [self.write_skill(s, overwrite=overwrite) for s in skills]

--- a/src/doit_cli/templates/skills/doit.checkin/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.checkin/SKILL.md
@@ -1,0 +1,452 @@
+---
+name: doit.checkin
+description: Finalize feature implementation, close issues, update roadmaps, and create pull request
+when_to_use: 'Use when the user is ready to finalize a feature implementation: close GitHub issues, update the roadmap, and
+  create a pull request.'
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[optional PR notes]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities (roadmap content is already loaded)
+- Identify connections to related specifications
+- Determine if roadmap files exist (absence means empty context section)
+
+**DO NOT read these files again for context** (already loaded above):
+
+- `.doit/memory/constitution.md` - principles are in context
+- `.doit/memory/roadmap.md` - content is in context (read for MODIFICATION only in step 6)
+- `.doit/memory/completed_roadmap.md` - content is in context
+
+**Legitimate explicit reads** (for modification, NOT in context show):
+
+- `specs/{feature}/spec.md` - feature details for documentation
+- `specs/{feature}/tasks.md` - completion status
+- `specs/{feature}/review-report.md` - code review status
+- `specs/{feature}/test-report.md` - test status
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. **Setup**: Run `.doit/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+
+2. **Load checkin context**:
+   - **REQUIRED**: Read spec.md for feature name and requirements
+   - **REQUIRED**: Read tasks.md for completion status
+   - **IF EXISTS**: Read review-report.md for code review status
+   - **IF EXISTS**: Read test-report.md for test status
+
+3. **Retrieve GitHub issues for feature**:
+   - Detect GitHub remote: `git remote get-url origin`
+   - If GitHub remote found:
+     - Search for Epic issue matching feature branch name
+     - Search for Feature issues linked to the Epic
+     - Search for Task issues linked to Features
+     - Build issue hierarchy tree
+   - If no GitHub remote: Skip issue management, proceed to step 6
+
+4. **Review issue completion status**:
+   - For each issue in hierarchy:
+     - Check if issue is open or closed
+     - Compare against tasks.md completion
+   - Generate status summary:
+
+     ```text
+     ## Issue Status
+
+     ### Epic: #XXX - [Epic Name]
+     Status: OPEN
+
+     ### Features
+     | Issue | Title | Status | Tasks Done |
+     |-------|-------|--------|------------|
+     | #YYY | Feature A | OPEN | 5/5 |
+     | #ZZZ | Feature B | OPEN | 3/4 |
+
+     ### Tasks
+     | Issue | Title | Status |
+     |-------|-------|--------|
+     | #AAA | Task 1 | CLOSED |
+     | #BBB | Task 2 | OPEN |
+     ```
+
+5. **Handle incomplete issues**:
+   - If any issues are still open but tasks show complete:
+     - List the incomplete issues
+     - Ask: "The following issues are still open. Do you want to close them? (yes/no/select)"
+     - If "select": Present each issue for individual decision
+   - If tasks show incomplete work:
+     - Warn: "Some tasks are not marked complete in tasks.md"
+     - Ask: "Do you want to proceed anyway? (yes/no)"
+   - Close approved issues via GitHub API
+
+6. **Update roadmap files** (FR-039, FR-040):
+
+   #### 6.1 Get Current Feature Branch
+
+   ```bash
+   git branch --show-current
+   ```
+
+   Extract the feature pattern (e.g., `008-doit-roadmapit-command` from branch name).
+
+   #### 6.2 Check and Update roadmap.md
+
+   - Roadmap availability is known from context show (if section was empty, file doesn't exist)
+     - If no roadmap in context: Log "No roadmap.md found, skipping roadmap archive"
+     - If roadmap exists (was in context):
+       1. Read the roadmap file **for modification** (context has summary, need full file to edit)
+       2. Search for items with matching feature branch reference `[###-feature-name]`
+          - Pattern: Items containing backtick references like `` `008-feature-name` `` or `[008-feature-name]`
+       3. For each matching item found:
+          - Extract: item text, priority (P1-P4), rationale
+          - Remove the item from its current priority section
+          - Mark as completed with `[x]` if using checkbox format
+
+   #### 6.3 Archive to completed_roadmap.md
+
+   - completed_roadmap availability is known from context show
+   - Read file **for modification** if it exists:
+     - If NOT exists:
+       1. Copy template from `.doit/templates/completed-roadmap-template.md`
+       2. Replace `[PROJECT_NAME]` with project name
+       3. Replace `[DATE]` with current date
+       4. If template not found, create with basic structure:
+          ```markdown
+          # Completed Roadmap Items
+
+          **Project**: [Project Name]
+          **Created**: [Date]
+
+          ## Recently Completed
+
+          | Item | Original Priority | Completed Date | Feature Branch | Notes |
+          |------|-------------------|----------------|----------------|-------|
+          ```
+     - If exists: Load existing file
+
+   - For each matched roadmap item:
+     1. Add to "Recently Completed" table with:
+        - Item text (without the branch reference)
+        - Original priority (P1-P4)
+        - Completion date (today's date)
+        - Feature branch reference (`` `###-feature-name` ``)
+        - Notes (from spec.md summary if available)
+
+   - **Maintain 20-item limit** in Recently Completed:
+     1. Count items in "Recently Completed" section
+     2. If count > 20:
+        - Move oldest items (beyond 20) to Archive section
+        - Update Statistics section with new counts (P1, P2, P3, P4 totals)
+
+   #### 6.4 Write Updated Files
+
+   - Write updated roadmap.md (with completed items removed)
+   - Write updated completed_roadmap.md (with new completed items)
+
+   #### 6.5 Report Roadmap Changes
+
+   ```markdown
+   ## Roadmap Archive Summary
+
+   **Items Archived**: [N]
+   | Item | Original Priority |
+   |------|-------------------|
+   | [item text] | P[N] |
+
+   **Files Updated**:
+   - `.doit/memory/roadmap.md` - Removed [N] completed items
+   - `.doit/memory/completed_roadmap.md` - Added [N] items to archive
+   ```
+
+   If no matching items found: Log "No matching roadmap items found for branch [branch-name]"
+
+7. **Generate feature documentation** in docs/:
+   - Create `docs/features/[feature-name].md`:
+
+     ```markdown
+     # [Feature Name]
+
+     **Completed**: [date]
+     **Branch**: [branch name]
+     **PR**: #XXX
+
+     ## Overview
+     [Summary from spec.md]
+
+     ## Requirements Implemented
+     | ID | Description | Status |
+     |----|-------------|--------|
+     | FR-001 | ... | Done |
+
+     ## Technical Details
+     [Key decisions from plan.md]
+
+     ## Files Changed
+     [List from tasks.md]
+
+     ## Testing
+     - Automated tests: [summary from test-report.md]
+     - Manual tests: [summary from review-report.md]
+
+     ## Related Issues
+     - Epic: #XXX
+     - Features: #YYY, #ZZZ
+     - Tasks: #AAA, #BBB, ...
+     ```
+
+8. **Prepare git commit**:
+   - Stage all changes: `git add -A`
+   - Generate commit message from feature context:
+
+     ```text
+     feat([feature-name]): [brief description]
+
+     Implements [Epic/Feature name] with the following:
+     - [Key change 1]
+     - [Key change 2]
+     - [Key change 3]
+
+     Closes #XXX, #YYY, #ZZZ
+
+     Requirements: FR-001, FR-002, ...
+     Tests: X passed, Y manual verified
+     ```
+
+   - Execute commit: `git commit -m "[message]"`
+
+9. **Create pull request**:
+   - Determine target branch:
+     - Check $ARGUMENTS for `--target [branch]` flag
+     - If not specified, check for `develop` branch
+     - If no `develop`, use `main` or `master`
+   - Check for gh CLI:
+     - Run `which gh` to verify installation
+     - If not found: Output manual PR instructions and skip (FR-044 fallback)
+   - If gh CLI available:
+     - Push branch: `git push -u origin [branch]`
+     - Create PR:
+
+       ```bash
+       gh pr create \
+         --title "feat([feature]): [description]" \
+         --body "[PR body from template]" \
+         --base [target-branch]
+       ```
+
+   - PR body template:
+
+     ```markdown
+     ## Summary
+     [Brief description from spec.md]
+
+     ## Changes
+     - [List of key changes]
+
+     ## Testing
+     - [ ] Automated tests pass
+     - [ ] Manual testing complete
+     - [ ] Code review approved
+
+     ## Requirements
+     | ID | Description | Status |
+     |----|-------------|--------|
+     | FR-XXX | ... | Done |
+
+     ## Related Issues
+     Closes #XXX, #YYY, #ZZZ
+
+     ---
+     Generated by `/doit.checkin`
+     ```
+
+10. **Handle missing gh CLI** (FR-044 fallback):
+    - If gh CLI not installed:
+
+      ```text
+      ## Manual PR Creation Required
+
+      The gh CLI is not installed. Please create a PR manually:
+
+      1. Push your branch:
+         git push -u origin [branch-name]
+
+      2. Create PR at:
+         https://github.com/[owner]/[repo]/compare/[target]...[branch]
+
+      3. Use this PR template:
+         [output template content]
+
+      4. Link these issues:
+         - Closes #XXX, #YYY, #ZZZ
+      ```
+
+11. **Handle missing develop branch** (fallback):
+    - If target branch doesn't exist:
+      - Check for `main`, then `master`
+      - If none found, ask user for target branch name
+
+12. **Report**: Output summary:
+    - Issues closed (count)
+    - Roadmap updated (yes/no)
+    - Documentation generated (path)
+    - Commit created (hash)
+    - PR created (URL) or manual instructions
+    - Next steps (merge PR, delete branch after merge)
+
+## Key Rules
+
+- Use absolute paths for all file operations
+- Never force-push or modify git history
+- Always confirm before closing issues
+- Generate documentation even if GitHub unavailable
+- Provide manual fallbacks for all GitHub operations
+- Include issue references in commit message for auto-linking
+
+---
+
+## Error Recovery
+
+### Incomplete Issues
+
+Some GitHub issues linked to this feature are still open or incomplete.
+
+**ERROR** | If issues are flagged as incomplete during checkin:
+
+1. List open issues for this feature: `gh issue list --label "{feature-label}"`
+2. For each open issue, decide: close it (if done), or defer it to the roadmap
+3. Close completed issues: `gh issue close {issue_number}`
+4. If deferring, add a comment explaining the deferral: `gh issue comment {issue_number} --body "Deferred to next iteration"`
+5. Verify: re-run `/doit.checkin` and confirm all issues are resolved
+
+> Prevention: Review the issue status board before starting checkin
+
+If the above steps don't resolve the issue: use `--force` flag if available, or manually close all issues and re-run.
+
+### GitHub API Failure
+
+The pull request or issue updates could not be completed due to a GitHub API error.
+
+**ERROR** | If GitHub API calls fail during checkin:
+
+1. Check your authentication: `gh auth status`
+2. Check GitHub service status: visit github.com/status or run `gh api /rate_limit`
+3. If rate-limited, wait for the reset time shown in the rate limit response
+4. Retry the checkin: re-run `/doit.checkin`
+5. Verify: `gh pr list --head $(git branch --show-current)` shows the PR
+
+> Prevention: Run `gh auth status` before starting the checkin process
+
+If the above steps don't resolve the issue: create the PR manually with `gh pr create` and close issues by hand.
+
+### Branch Push Rejected
+
+The feature branch could not be pushed to the remote repository.
+
+**ERROR** | If `git push` is rejected:
+
+1. Fetch the latest remote state: `git fetch origin`
+2. Check if the remote branch has new commits: `git log HEAD..origin/$(git branch --show-current) --oneline`
+3. If behind, rebase: `git rebase origin/$(git branch --show-current)`
+4. Resolve any conflicts, then push: `git push origin $(git branch --show-current)`
+5. Verify: `git status` shows "Your branch is up to date"
+
+> Prevention: Pull/rebase before starting checkin to avoid push conflicts
+
+If the above steps don't resolve the issue: check repository permissions and branch protection rules.
+
+### PR Creation Conflict
+
+A pull request already exists for this branch or conflicts with an existing PR.
+
+**WARNING** | If PR creation fails due to a conflict:
+
+1. Check for existing PRs: `gh pr list --head $(git branch --show-current)`
+2. If a PR already exists, update it instead of creating a new one: `gh pr edit {pr_number}`
+3. If the existing PR is outdated, close it and create a new one: `gh pr close {pr_number} && gh pr create`
+4. Verify: `gh pr view` shows the correct PR with updated content
+
+> Prevention: Check for existing PRs with `gh pr list --head $(git branch --show-current)` before creating new ones
+
+If the above steps don't resolve the issue: manually create the PR through the GitHub web interface.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (PR merged or ready to merge)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌───────────────────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                                    │
+│  ● specit → ● planit → ● taskit → ● implementit → ● testit → ● reviewit → ● checkin  │
+└───────────────────────────────────────────────────────────────────────────────────────┘
+
+**Status**: Feature complete! 🎉
+
+**Recommended**: Run `/doit.roadmapit` to update the project roadmap with this completion.
+
+**Alternative**: Run `/doit.specit [next feature]` to start the next feature development.
+```
+
+### On Partial Success (PR created, pending merge)
+
+If the PR was created but not yet merged:
+
+```markdown
+---
+
+## Next Steps
+
+┌───────────────────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                                    │
+│  ● specit → ● planit → ● taskit → ● implementit → ● testit → ● reviewit → ◐ checkin  │
+└───────────────────────────────────────────────────────────────────────────────────────┘
+
+**Status**: PR created and awaiting merge.
+
+**Next**: Merge the PR when ready, then run `/doit.roadmapit` to update the project roadmap.
+```

--- a/src/doit_cli/templates/skills/doit.constitution/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.constitution/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: doit.constitution
+description: Create or update the project constitution from interactive or provided principle inputs, keeping dependent templates in sync.
+when_to_use: Use when the user asks to create, amend, or clean up the project constitution, set up initial tech stack + governance rules, or run `/doit.constitution cleanup` to split tech stack out of constitution.md.
+allowed-tools: Read Write Edit Glob Grep Bash(doit *) Bash(mkdir *) Bash(ls *) Bash(touch *) Bash(rm *) Bash(df *)
+argument-hint: "[cleanup|--dry-run|--merge | principles description]"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Cleanup Subcommand
+
+If the user requests "cleanup" or "separate tech stack", use the CLI command:
+
+```bash
+# Preview what would be changed
+doit constitution cleanup --dry-run
+
+# Perform the cleanup (creates backup automatically)
+doit constitution cleanup
+
+# Merge with existing tech-stack.md if it already exists
+doit constitution cleanup --merge
+```
+
+The cleanup command:
+
+- Analyzes constitution.md for tech-stack sections (Tech Stack, Infrastructure, Deployment)
+- Creates a timestamped backup of constitution.md
+- Extracts tech sections to a new tech-stack.md
+- Adds cross-references between both files
+
+After running cleanup, inform the user about the two files:
+
+- `.doit/memory/constitution.md` - Principles, governance, quality standards, workflow
+- `.doit/memory/tech-stack.md` - Languages, frameworks, libraries, infrastructure, deployment
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference existing constitution principles (if updating existing constitution)
+- Consider roadmap priorities (already in context)
+- Identify connections to related specifications
+
+**Note**: Constitution is the source file being modified, so reading it for modification is legitimate.
+
+**DO NOT read these files again** (already in context above):
+
+- `.doit/memory/roadmap.md` - priorities are in context
+- `.doit/memory/tech-stack.md` - tech decisions are in context (unless modifying it)
+
+**Legitimate explicit reads** (for template sync validation in step 6):
+
+- `.doit/templates/plan-template.md` - for consistency check
+- `.doit/templates/spec-template.md` - for consistency check
+- `.doit/templates/tasks-template.md` - for consistency check
+- `.doit/templates/commands/*.md` - for consistency check
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+You are updating the project constitution at `.doit/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+Follow this execution flow:
+
+1. Load the existing constitution template at `.doit/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. **Section-by-Section Update Mode**:
+   If user input specifies a particular section to update (e.g., "update tech stack" or "change deployment"), focus on that section only while preserving other sections. Supported section keywords:
+   - "purpose" / "goals" → Purpose & Goals section
+   - "tech" / "stack" / "language" → Tech Stack section
+   - "infrastructure" / "hosting" / "cloud" → Infrastructure section
+   - "deployment" / "ci" / "cd" → Deployment section
+   - "principles" → Core Principles section
+   - "governance" → Governance section
+
+   If no specific section mentioned, proceed with full constitution review.
+
+3. **Guided Prompts for New Placeholders**:
+   When collecting values for the following placeholders, use these prompts if values not provided:
+
+   **Purpose & Goals:**
+   - [PROJECT_PURPOSE]: "What is the main purpose of this project? What problem does it solve?"
+   - [SUCCESS_CRITERIA]: "What are the key success metrics or criteria for this project?"
+
+   **Tech Stack (FR-005, FR-006):**
+   - [PRIMARY_LANGUAGE]: "What programming language(s) will this project use? (e.g., Python 3.11+, TypeScript)"
+   - [FRAMEWORKS]: "What frameworks will you use? (e.g., FastAPI, React, Django)"
+   - [KEY_LIBRARIES]: "What key libraries/packages are essential? (e.g., Pydantic, SQLAlchemy)"
+
+   **Infrastructure (FR-007, FR-008):**
+   - [HOSTING_PLATFORM]: "Where will this be hosted? (e.g., AWS ECS, Google Cloud Run, Vercel, self-hosted)"
+   - [CLOUD_PROVIDER]: "Which cloud provider? (AWS, GCP, Azure, multi-cloud, on-premises)"
+   - [DATABASE]: "What database(s) will you use? (e.g., PostgreSQL, MongoDB, none)"
+
+   **Deployment:**
+   - [CICD_PIPELINE]: "What CI/CD system? (e.g., GitHub Actions, GitLab CI, Jenkins)"
+   - [DEPLOYMENT_STRATEGY]: "What deployment strategy? (blue-green, rolling, canary, manual)"
+   - [ENVIRONMENTS]: "What environments? (e.g., dev, staging, production)"
+
+4. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+5. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+6. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.doit/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.doit/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.doit/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.doit/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+7. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+8. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+9. Write the completed constitution back to `.doit/memory/constitution.md` (overwrite).
+
+10. Output a final summary to the user with:
+    - New version and bump rationale.
+    - Any files flagged for manual follow-up.
+    - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.doit/memory/constitution.md` file.
+
+## Context Sources Reference
+
+Other commands access project configuration via `doit context show`, which loads:
+
+**Constitution** (`.doit/memory/constitution.md`):
+
+- Purpose & Goals - Project purpose and success criteria
+- Core Principles - Non-negotiable project rules
+- Quality Standards - Testing and quality requirements
+- Development Workflow - Step-by-step process
+- Governance - Amendment rules and compliance
+
+**Tech Stack** (`.doit/memory/tech-stack.md`):
+
+- Languages - Primary and secondary languages
+- Frameworks - Application frameworks
+- Libraries - Key dependencies
+- Infrastructure - Hosting, cloud provider, database
+- Deployment - CI/CD, strategy, environments
+
+**Usage in other commands**:
+
+```text
+# At the start of any command that needs project context:
+1. Run `doit context show` - this loads constitution, tech-stack, roadmap automatically
+2. Use the loaded context directly - DO NOT read memory files again
+3. Only read files explicitly when they need to be MODIFIED (not just referenced)
+4. Feature-specific artifacts (plan.md, spec.md, contracts/) require explicit reads
+```
+
+---
+
+## Error Recovery
+
+### Validation Failure
+
+The constitution content did not pass validation checks.
+
+**ERROR** | If constitution validation fails:
+
+1. Review the validation output for specific failing checks
+2. Common issues: missing required sections, invalid format, contradictory principles
+3. Edit the constitution to fix the flagged issues
+4. Re-run `/doit.constitution` to validate again
+5. Verify: validation passes with no errors
+
+> Prevention: Use the constitution template as a guide to ensure all required sections are present
+
+If the above steps don't resolve the issue: compare your constitution with the template at `.doit/templates/constitution-template.md` for structural guidance.
+
+### File Write Permission Denied
+
+The constitution file could not be saved to the project memory directory.
+
+**ERROR** | If the constitution file cannot be written:
+
+1. Check directory permissions: `ls -la .doit/memory/`
+2. Verify the memory directory exists: `ls -d .doit/memory/`
+3. If missing, create it: `mkdir -p .doit/memory/`
+4. Check disk space: `df -h .`
+5. Verify: `touch .doit/memory/test && rm .doit/memory/test` confirms write access
+
+> Prevention: Verify write permissions to `.doit/memory/` before making constitution changes
+
+If the above steps don't resolve the issue: check if the filesystem is read-only or if you need elevated permissions.
+
+### Dependent Templates Out of Sync
+
+Templates that depend on the constitution are outdated after a constitution change.
+
+**WARNING** | If dependent templates reference outdated constitution content:
+
+1. After updating the constitution, run `doit sync-prompts` to propagate changes
+2. Check if command templates reference the old tech stack or principles
+3. If specific templates are outdated, they will be updated on next sync
+4. Verify: `doit sync-prompts` completes without errors
+
+> Prevention: Always run `doit sync-prompts` after updating the constitution
+
+If the above steps don't resolve the issue: manually update the affected templates to reference the new constitution content.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (constitution created or updated)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+**Constitution updated successfully!**
+
+**Recommended**: Run `/doit.scaffoldit` to generate project structure based on the tech stack in your constitution.
+
+**Alternative**: Run `/doit.specit [feature description]` to create a feature specification for your first feature.
+```

--- a/src/doit_cli/templates/skills/doit.fixit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.fixit/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: doit.fixit
+description: Start and manage bug-fix workflows for GitHub issues
+when_to_use: Use when the user reports a bug, wants to start a bug-fix workflow, or references a specific GitHub issue by
+  number.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[issue-number | bug description]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+This command manages the bug-fix workflow lifecycle for GitHub issues.
+
+### 1. Parse Command Arguments
+
+Extract the operation from `$ARGUMENTS`:
+
+| Pattern | Operation | Example |
+|---------|-----------|---------|
+| `start <issue_id>` | Start workflow for issue | `/doit.fixit start 123` |
+| `start` | Interactive issue selection | `/doit.fixit start` |
+| `list` | List open bugs | `/doit.fixit list` |
+| `status [issue_id]` | Show workflow status | `/doit.fixit status` |
+| `investigate [issue_id]` | Start/manage investigation | `/doit.fixit investigate` |
+| `plan [issue_id]` | Generate fix plan | `/doit.fixit plan` |
+| `review [issue_id]` | Review and approve plan | `/doit.fixit review` |
+| `cancel [issue_id]` | Cancel workflow | `/doit.fixit cancel` |
+| `workflows` | List all workflows | `/doit.fixit workflows` |
+
+### 2. Workflow Phases
+
+The fixit workflow progresses through these phases:
+
+```
+initialized → investigating → planning → reviewing → approved → implementing → completed
+                    ↓              ↓          ↓
+                cancelled      cancelled   cancelled
+```
+
+### 3. Start Workflow
+
+When starting a new workflow (`doit fixit start <issue_id>`):
+
+1. Verify the GitHub issue exists and is open
+2. Check no existing workflow for this issue
+3. Create fix branch: `fix/{issue_id}-{slug}`
+4. Initialize workflow state in `.doit/state/fixit-{issue_id}.json`
+5. Display next steps for investigation
+
+### 4. Investigation Phase
+
+Run `doit fixit investigate` to:
+
+1. Extract keywords from issue title/body
+2. Create checkpoints for investigation:
+   - Review error logs and stack traces
+   - Identify affected code paths
+   - Search for related issues or commits
+   - Formulate root cause hypothesis
+3. Add findings with types:
+   - `hypothesis` - Initial theories
+   - `confirmed_cause` - Verified root cause
+   - `affected_file` - Files that need changes
+   - `reproduction_step` - Steps to reproduce
+
+Example:
+```bash
+doit fixit investigate -a "Null pointer in click handler" -t confirmed_cause
+doit fixit investigate -c cp-1  # Complete checkpoint
+doit fixit investigate --done    # Finish investigation
+```
+
+### 5. Planning Phase
+
+Run `doit fixit plan --generate` to:
+
+1. Extract confirmed root cause from investigation
+2. Identify affected files from findings
+3. Generate fix plan with:
+   - Root cause summary
+   - Proposed solution
+   - Files to modify
+   - Risk assessment (low/medium/high)
+4. Save plan to workflow state
+
+### 6. Review and Approval
+
+Run `doit fixit review` to:
+
+1. Display the fix plan for review
+2. Use `--approve` to approve the plan
+3. On approval, advance to implementing phase
+
+### 7. Implementation
+
+After plan approval:
+
+1. Run `/doit.implementit` to execute the fix
+2. The fix plan guides the implementation
+3. Workflow tracks implementation progress
+
+### 8. Completion
+
+Run `/doit.checkin` to:
+
+1. Create pull request
+2. Link PR to GitHub issue
+3. Mark workflow as completed
+4. Optionally close the GitHub issue
+
+---
+
+## Key Rules
+
+- Always verify GitHub issue exists before starting
+- Require confirmed_cause finding before planning
+- Require plan approval before implementation
+- Branch naming: `fix/{issue_id}-{slug}`
+- State persistence: `.doit/state/fixit-{issue_id}.json`
+
+---
+
+## Investigation Checkpoint Examples
+
+Different bug types require different investigation approaches. Use these as templates:
+
+### UI/Frontend Bug
+
+```text
+Checkpoints:
+  cp-1: Reproduce in browser (note steps, screenshots)
+  cp-2: Check browser console for errors/warnings
+  cp-3: Inspect network requests for failed API calls
+  cp-4: Trace component render cycle and state
+  cp-5: Identify root cause in component tree
+
+Findings:
+  - type: reproduction_step
+    detail: "Click submit with empty form -> TypeError in console"
+  - type: affected_file
+    detail: "src/components/Form.tsx:42 - missing null check on props.onSubmit"
+  - type: confirmed_cause
+    detail: "Optional callback prop accessed without guard"
+```
+
+### API/Backend Bug
+
+```text
+Checkpoints:
+  cp-1: Review error logs and stack traces
+  cp-2: Reproduce with curl/httpie (exact request)
+  cp-3: Check input validation and edge cases
+  cp-4: Trace code path from endpoint to error
+  cp-5: Review database queries and data state
+
+Findings:
+  - type: reproduction_step
+    detail: "POST /api/items with duplicate name -> 500 Internal Server Error"
+  - type: affected_file
+    detail: "src/services/item_service.py:88 - unhandled IntegrityError"
+  - type: confirmed_cause
+    detail: "Missing unique constraint error handling in create_item()"
+```
+
+### Data/Migration Bug
+
+```text
+Checkpoints:
+  cp-1: Identify affected records/data
+  cp-2: Check migration history and schema state
+  cp-3: Compare expected vs actual data
+  cp-4: Trace data transformation pipeline
+  cp-5: Verify rollback safety
+
+Findings:
+  - type: hypothesis
+    detail: "Migration 003 may have dropped column before data was moved"
+  - type: confirmed_cause
+    detail: "Migration ordering: column dropped in 003, data migration in 004"
+```
+
+### Performance Bug
+
+```text
+Checkpoints:
+  cp-1: Establish baseline metrics (response time, memory, CPU)
+  cp-2: Profile the slow operation
+  cp-3: Identify bottleneck (N+1 query, large payload, blocking I/O)
+  cp-4: Check for missing indexes or cache misses
+  cp-5: Design optimization approach
+
+Findings:
+  - type: reproduction_step
+    detail: "GET /api/reports with 10k+ records -> 12s response time"
+  - type: confirmed_cause
+    detail: "N+1 query: loading related items individually in loop"
+```
+
+---
+
+## Error Recovery
+
+### Workflow State Corruption
+
+The workflow state file is unreadable or contains invalid data.
+
+**FATAL** | Your investigation progress may be lost if the state file is unrecoverable. If `.doit/state/fixit-{issue_id}.json` becomes corrupted:
+
+1. Run `doit fixit status {issue_id}` to see current state
+2. If unreadable, delete the state file and restart: `doit fixit start {issue_id}`
+3. Re-add key investigation findings manually
+4. Verify: `doit fixit status {issue_id}` shows valid workflow state
+
+> Prevention: Avoid manually editing state files in `.doit/state/`
+
+If the above steps don't resolve the issue: recreate the workflow from scratch and document previous findings in the GitHub issue comments.
+
+### GitHub Issue Not Found
+
+The referenced GitHub issue does not exist or is inaccessible.
+
+**ERROR** | If the issue was closed, deleted, or transferred:
+
+1. Check issue status: `gh issue view {issue_id}`
+2. If transferred, update the workflow with the new issue number
+3. If closed by mistake, reopen: `gh issue reopen {issue_id}`
+4. Verify: `gh issue view {issue_id}` shows the issue details
+
+> Prevention: Confirm the issue number before starting a workflow
+
+If the above steps don't resolve the issue: create a new issue describing the bug and start a fresh workflow.
+
+### Branch Conflicts
+
+The fix branch has merge conflicts with the base branch.
+
+**ERROR** | If the fix branch has merge conflicts with the base branch:
+
+1. Fetch latest: `git fetch origin`
+2. Rebase onto target: `git rebase origin/main` (or develop)
+3. Resolve conflicts, then continue the workflow
+4. Do NOT force-push without confirming with the team
+5. Verify: `git status` shows no merge conflicts remaining
+
+> Prevention: Rebase frequently against the base branch during long-running fixes
+
+If the above steps don't resolve the issue: consider creating a new branch from the latest base and cherry-picking your fix commits.
+
+### Investigation Dead End
+
+The investigation did not identify a root cause for the bug.
+
+**WARNING** | If investigation doesn't reveal a root cause:
+
+1. Add a `hypothesis` finding documenting what was ruled out
+2. Run `doit fixit investigate --done` to close the investigation
+3. Add a comment to the GitHub issue requesting more information
+4. Consider running `doit fixit cancel {issue_id}` if the bug is not reproducible
+5. Verify: the GitHub issue has a comment summarizing investigation findings
+
+> Prevention: Set a time limit for investigation and request more context early if needed
+
+If the above steps don't resolve the issue: escalate by tagging relevant team members on the GitHub issue for additional input.
+
+### Plan Rejected After Review
+
+The fix plan was not approved and needs changes.
+
+**WARNING** | If the fix plan needs revision:
+
+1. The workflow stays in `reviewing` phase
+2. Run `doit fixit plan --generate` again with updated investigation findings
+3. Review the new plan with `doit fixit review`
+4. Verify: `doit fixit status {issue_id}` shows the workflow advanced past `reviewing`
+
+> Prevention: Include thorough investigation findings before generating the plan
+
+If the above steps don't resolve the issue: add more investigation findings to strengthen the root cause analysis before regenerating the plan.
+
+---
+
+## Next Steps
+
+After completing this command, display recommendations:
+
+### On Workflow Started
+
+```markdown
+**Workflow started for issue #123!**
+
+**Recommended**: Run `/doit.fixit investigate` to start the investigation phase.
+```
+
+### On Investigation Complete
+
+```markdown
+**Investigation complete!**
+
+**Recommended**: Run `/doit.fixit plan --generate` to create a fix plan.
+```
+
+### On Plan Approved
+
+```markdown
+**Plan approved!**
+
+**Recommended**: Run `/doit.implementit` to implement the fix.
+```

--- a/src/doit_cli/templates/skills/doit.implementit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.implementit/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: doit.implementit
+description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+when_to_use: Use when the user is ready to execute tasks.md for the current feature and produce the source code changes, following
+  the plan.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[optional task id]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. Run `.doit/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Check for `--skip-checklist` in $ARGUMENTS - if present, skip checklist verification
+   - If not skipped, scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+10. **Generate Completion Summary Report**:
+    - Create a summary showing:
+
+      ```text
+      ## Implementation Summary
+
+      **Feature**: [Feature name from spec.md]
+      **Branch**: [Current git branch]
+
+      ### Task Completion
+      | Phase | Total | Completed | Status |
+      |-------|-------|-----------|--------|
+      | Setup | X | X | ✓ |
+      | Core | X | X | ✓ |
+      | ... | ... | ... | ... |
+
+      ### Files Modified
+      - [List of files created/modified]
+
+      ### Tests Status
+      - Unit tests: X passed, Y failed
+      - Integration tests: X passed, Y failed
+
+      ### Next Steps
+      - Run `/doit.reviewit` for code review
+      - Run `/doit.testit` for full test execution
+      ```
+
+    - Output summary to console for immediate feedback
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/doit.taskit` first to regenerate the task list.
+
+---
+
+## Error Recovery
+
+### Missing Task List
+
+The task list needed for implementation was not found.
+
+**ERROR** | If `tasks.md` is not found in the feature specs directory:
+
+1. Check if the file exists: `ls specs/*/tasks.md`
+2. If missing, generate it: run `/doit.taskit` to create tasks from the plan
+3. If the file exists but in a different directory, verify you're on the correct feature branch: `git branch --show-current`
+4. Verify: `ls specs/$(git branch --show-current | sed 's/^[0-9]*-//')/tasks.md` should show the file
+
+> Prevention: Always run `/doit.taskit` before `/doit.implementit`
+
+If the above steps don't resolve the issue: verify the feature branch name matches the spec directory name.
+
+### Task Execution Failure
+
+A task failed during implementation, but your other completed work is safe.
+
+**ERROR** | Your progress IS preserved — completed tasks are saved in `.doit/state/`. If a task fails during execution:
+
+1. Note the failing task ID and error message
+2. Check if the failure is due to a missing dependency or file: review the error output
+3. Fix the underlying issue (install dependency, correct file path, etc.)
+4. Resume implementation — the workflow will continue from the failed task
+5. Verify: check the task is now marked complete in `tasks.md`
+
+If the above steps don't resolve the issue: skip the failing task by marking it `[x]` in tasks.md with a comment explaining why, then continue with the next task.
+
+### State File Corruption
+
+The workflow state file has become unreadable or corrupted.
+
+**FATAL** | Your progress in `.doit/state/` may be lost. If the workflow state file is corrupted:
+
+1. Check the state directory: `ls -la .doit/state/`
+2. If the JSON state file is unreadable, delete it: `rm .doit/state/workflow-*.json`
+3. Review `tasks.md` to identify which tasks are already marked `[x]` (completed)
+4. Re-run `/doit.implementit` — it will start from the first unchecked task
+5. Verify: `ls .doit/state/` shows a new, valid state file
+
+> Prevention: Avoid manually editing files in `.doit/state/` — let the workflow manage them
+
+If the above steps don't resolve the issue: back up your work with `git stash`, run `doit init` to reinitialize the project state, then `git stash pop` and restart implementation.
+
+### Test Failure During Implementation
+
+Tests are failing while implementing tasks, but you can continue working.
+
+**WARNING** | If tests fail during implementation:
+
+1. Review the test output to identify the failing test and the cause
+2. If the test failure is in code you just changed, fix the issue before proceeding
+3. If the test failure is pre-existing (not related to your changes), note it and continue
+4. Run the specific failing test in isolation: `pytest tests/path/to/test.py -x --tb=short`
+5. Verify: `pytest tests/ -x --tb=short` passes for your changed files
+
+> Prevention: Run tests after each task completion rather than waiting until the end
+
+If the above steps don't resolve the issue: run `/doit.testit` for a full test analysis and detailed failure report.
+
+### Interrupted Session
+
+The implementation session was interrupted before all tasks were completed.
+
+**WARNING** | Your progress IS preserved — completed tasks remain marked `[x]` in tasks.md. If the session was interrupted:
+
+1. Check current progress: review `tasks.md` for the last completed task (marked `[x]`)
+2. Note the next unchecked task — this is where implementation will resume
+3. Re-run `/doit.implementit` — it will automatically continue from the first unchecked task
+4. Verify: the previously completed tasks are still marked `[x]` and the next task begins execution
+
+If the above steps don't resolve the issue: manually review `tasks.md` and mark any tasks you know were completed as `[x]`, then re-run.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (all tasks complete)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ● planit → ● taskit → ● implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.testit` to verify your implementation with tests.
+
+**Alternative**: Run `/doit.reviewit` to request a code review.
+```
+
+### On Partial Completion (tasks remaining)
+
+If some tasks are still incomplete:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ● planit → ● taskit → ◐ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Status**: N tasks remaining out of M total.
+
+**Recommended**: Continue with `/doit.implementit` to complete remaining tasks.
+
+**Alternative**: Run `/doit.testit` for partial verification of completed work.
+```

--- a/src/doit_cli/templates/skills/doit.planit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.planit/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: doit.planit
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+when_to_use: Use when the user wants to turn a feature spec into an implementation plan with research, data model, contracts,
+  and quickstart artifacts.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[feature-name]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+- Use tech stack information (already included in constitution/tech-stack context)
+- Review related_specs for integration points with other features
+
+**DO NOT read these files again** (already in context above):
+
+- `.doit/memory/constitution.md` - principles are in context
+- `.doit/memory/tech-stack.md` - tech decisions are in context
+- `.doit/memory/roadmap.md` - priorities are in context
+- Current feature spec - available as current_spec in context
+
+**Legitimate explicit reads** (NOT in context show):
+
+- `specs/{feature}/research.md` - if research phase complete
+- `specs/{feature}/data-model.md` - if already generated
+- `specs/{feature}/contracts/*.yaml` - API contract files
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. **Setup**: Run `.doit/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Load IMPL_PLAN template (already copied). Feature spec and constitution are already available from `doit context show` above.
+
+3. **Extract Tech Stack from loaded context**:
+   - Tech stack is already loaded in context (from tech-stack.md or constitution.md)
+   - Extract: PRIMARY_LANGUAGE, FRAMEWORKS, KEY_LIBRARIES
+   - Extract: HOSTING_PLATFORM, CLOUD_PROVIDER, DATABASE
+   - Extract: CICD_PIPELINE, DEPLOYMENT_STRATEGY
+   - Store these values for architecture alignment validation
+
+4. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context using constitution tech stack as baseline
+   - Flag any tech choices that deviate from constitution (require justification)
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified or tech stack misalignment)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+5. **Generate Mermaid Visualizations** (FR-004, FR-005, FR-006, FR-007):
+
+   After filling the plan content, generate visual diagrams:
+
+   a. **Architecture Overview**:
+      - Parse Technical Context for: Language, Dependencies, Storage, Target Platform
+      - Identify architectural layers from Project Type:
+        - **single**: Presentation → Service → Data
+        - **web**: Frontend → API → Services → Database
+        - **mobile**: Mobile App → API → Services → Database
+      - Generate flowchart with subgraphs for each layer
+      - Replace content in `<!-- BEGIN:AUTO-GENERATED section="architecture" -->` markers
+
+      ```mermaid
+      flowchart TD
+          subgraph "Presentation"
+              UI[UI/CLI Layer]
+          end
+          subgraph "Application"
+              API[API/Routes]
+              SVC[Services]
+          end
+          subgraph "Data"
+              DB[(Database)]
+          end
+          UI --> API --> SVC --> DB
+      ```
+
+   b. **Component Dependencies**:
+      - Check if multiple services/components are defined in Project Structure
+      - **IF multiple services defined**:
+        - Parse service names from structure
+        - Generate dependency flowchart showing relationships
+        - Replace content in `<!-- BEGIN:AUTO-GENERATED section="component-dependencies" -->` markers
+      - **IF single service only**:
+        - **REMOVE the entire Component Dependencies section**
+        - Do NOT leave empty placeholder
+
+   c. **Data Model ER Diagram**:
+      - When generating data-model.md, add ER diagram at the top
+      - Parse entity definitions from the file
+      - Generate erDiagram showing all entities and relationships
+      - Insert in `<!-- BEGIN:AUTO-GENERATED section="er-diagram" -->` markers
+
+      ```mermaid
+      erDiagram
+          ENTITY1 ||--o{ ENTITY2 : "relationship"
+          ENTITY1 {
+              uuid id PK
+              string name
+          }
+      ```
+
+   d. **State Machine Detection**:
+      - Scan entities for fields named: `status`, `state`, `stage`, `phase`
+      - For each entity with state field:
+        - Parse possible state values from field type or comments
+        - Generate stateDiagram-v2 showing transitions
+        - Add after entity definition in data-model.md
+
+      ```mermaid
+      stateDiagram-v2
+          [*] --> Initial
+          Initial --> Active : activate
+          Active --> Complete : finish
+          Complete --> [*]
+      ```
+
+   e. **Diagram Validation**:
+      - Verify mermaid syntax is valid
+      - Check node count does not exceed limits (20 for flowchart, 10 for ER)
+      - If exceeding limits, split into subgraphs by domain/layer
+
+6. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Agent context update**:
+   - Run `.doit/scripts/bash/update-agent-context.sh claude`
+   - These scripts detect which AI agent is in use
+   - Update the appropriate agent-specific context file
+   - Add only new technology from current plan
+   - Preserve manual additions between markers
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+## Key rules
+
+- Use absolute paths
+- ERROR on gate failures or unresolved clarifications
+
+---
+
+## Error Recovery
+
+### Missing Feature Specification
+
+The specification file needed for planning was not found.
+
+**ERROR** | If `spec.md` is not found in the feature specs directory:
+
+1. Check if the spec exists: `ls specs/*/spec.md`
+2. If missing, create it: run `/doit.specit {feature-description}` to generate a specification
+3. If the spec exists but in a different directory, verify your feature branch: `git branch --show-current`
+4. Verify: `cat specs/{feature}/spec.md | head -5` shows the spec header
+
+> Prevention: Always run `/doit.specit` before `/doit.planit`
+
+If the above steps don't resolve the issue: verify the feature branch name matches the spec directory name.
+
+### Tech Stack Mismatch
+
+The planned technology choices conflict with the project constitution.
+
+**WARNING** | If the constitution check flags a tech stack deviation:
+
+1. Review the flagged deviation in the plan output
+2. Check the constitution: `cat .doit/memory/constitution.md | grep -A5 "Tech Stack"`
+3. If the deviation is intentional, add justification in the Complexity Tracking section of plan.md
+4. If unintentional, update the Technical Context to align with the constitution
+5. Verify: re-run `/doit.planit` and confirm the constitution check passes
+
+> Prevention: Review the constitution tech stack before introducing new technologies
+
+If the above steps don't resolve the issue: amend the constitution via `/doit.constitution` if the new technology should become standard.
+
+### Research File Not Found
+
+Research artifacts were expected but could not be loaded.
+
+**WARNING** | If research.md is not found during Phase 0:
+
+1. Check if research exists: `ls specs/{feature}/research.md`
+2. If missing, planning will proceed without research context — tech decisions will rely on spec.md alone
+3. If you want research context, run `/doit.researchit` first, then re-run `/doit.planit`
+4. Verify: plan.md is generated with or without research context
+
+> Prevention: Complete `/doit.researchit` and `/doit.specit` before running `/doit.planit`
+
+If the above steps don't resolve the issue: proceed without research — the plan can be updated later when research is available.
+
+### Agent Context Update Failure
+
+The AI agent context file could not be updated after planning.
+
+**WARNING** | If the agent context update script fails:
+
+1. Check if the script exists: `ls .doit/scripts/bash/update-agent-context.sh`
+2. Try running it manually: `bash .doit/scripts/bash/update-agent-context.sh claude`
+3. If the script fails, the plan itself is still valid — only the agent context file is affected
+4. Verify: `cat CLAUDE.md | tail -20` to check if new technology was added
+
+If the above steps don't resolve the issue: manually add new technology references to CLAUDE.md under the Active Technologies section.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (plan and artifacts created)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ● planit → ○ taskit → ○ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.taskit` to create implementation tasks from this plan.
+```
+
+### On Success with Existing Tasks
+
+If `tasks.md` already exists in the specs directory:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ● planit → ● taskit → ○ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.implementit` to begin executing the existing tasks.
+
+**Alternative**: Run `/doit.taskit` to regenerate tasks based on the updated plan.
+```
+

--- a/src/doit_cli/templates/skills/doit.reviewit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.reviewit/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: doit.reviewit
+description: Review implemented code for quality and completeness against specifications
+when_to_use: 'Use when the user wants a code review of the current feature: quality checks, coverage, completeness against
+  spec, and manual-test planning.'
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[optional focus area]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. **Setup**: Run `.doit/scripts/bash/check-prerequisites.sh --json --require-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+
+2. **Load review context**:
+   - **REQUIRED**: Read spec.md for requirements and acceptance criteria
+   - **REQUIRED**: Read plan.md for technical decisions and architecture
+   - **REQUIRED**: Read tasks.md for implementation details and file paths
+   - **IF EXISTS**: Read data-model.md for entity definitions
+   - **IF EXISTS**: Read contracts/ for API specifications
+
+3. **Detect implemented files** from tasks.md:
+   - Parse completed tasks (marked with [X])
+   - Extract file paths from task descriptions
+   - Build list of files to review
+   - Group files by category: models, services, endpoints, tests, config
+
+4. **Execute code review** against requirements:
+   - For each implemented file:
+     - Read file contents
+     - Compare against relevant spec requirements
+     - Check adherence to plan.md architecture decisions
+     - Verify data model compliance (if data-model.md exists)
+     - Verify API contract compliance (if contracts/ exists)
+   - Generate findings with severity levels:
+     - **CRITICAL**: Requirement not implemented, security issue, data loss risk
+     - **MAJOR**: Partial implementation, performance concern, missing validation
+     - **MINOR**: Code style, documentation gap, minor deviation from plan
+     - **INFO**: Suggestion, optimization opportunity, best practice note
+
+5. **Format findings report**:
+
+   ```text
+   ## Code Review Findings
+
+   ### Critical (X findings)
+   | File | Issue | Requirement |
+   |------|-------|-------------|
+   | path/to/file.py | Description | FR-XXX |
+
+   ### Major (X findings)
+   ...
+
+   ### Minor (X findings)
+   ...
+
+   ### Info (X findings)
+   ...
+
+   ### Summary
+   - Total files reviewed: X
+   - Critical issues: X
+   - Major issues: X
+   - Minor issues: X
+   - Recommendations: [list]
+   ```
+
+6. **Extract manual test items** from spec.md:
+   - Parse acceptance criteria/scenarios from spec
+   - Extract testable items that require manual verification
+   - Items typically marked as "Given/When/Then" or acceptance criteria
+   - Create sequential test list with:
+     - Test ID (MT-001, MT-002, etc.)
+     - Description
+     - Expected outcome
+     - Prerequisites (if any)
+
+7. **Present manual tests sequentially**:
+   - For each manual test:
+
+     ```text
+     ## Manual Test MT-XXX
+
+     **Description**: [test description]
+     **Prerequisites**: [any setup needed]
+     **Steps**:
+     1. [step 1]
+     2. [step 2]
+     ...
+
+     **Expected Result**: [what should happen]
+
+     ---
+     Please execute this test and respond with:
+     - PASS: Test passed as expected
+     - FAIL: Test failed (describe what happened)
+     - SKIP: Cannot test right now (provide reason)
+     - BLOCK: Blocked by issue (describe blocker)
+     ```
+
+   - Wait for user response before proceeding to next test
+   - Track results in memory
+
+8. **Track test progress**:
+   - Maintain running tally:
+
+     ```text
+     Progress: X/Y tests completed
+     - Passed: X
+     - Failed: X
+     - Skipped: X
+     - Blocked: X
+     ```
+
+   - Display after each test completion
+
+9. **Collect sign-off**:
+   - After all manual tests complete, present summary:
+
+     ```text
+     ## Manual Testing Complete
+
+     | Test ID | Description | Result |
+     |---------|-------------|--------|
+     | MT-001 | ... | PASS |
+     | MT-002 | ... | FAIL |
+     ...
+
+     **Overall Status**: [PASS if no failures, FAIL otherwise]
+
+     Do you approve these results and sign off on manual testing? (yes/no)
+     ```
+
+   - Record sign-off response and timestamp
+
+10. **Generate review-report.md** in FEATURE_DIR:
+
+    ```markdown
+    # Review Report: [Feature Name]
+
+    **Date**: [timestamp]
+    **Reviewer**: [Claude]
+    **Branch**: [current branch]
+
+    ## Code Review Summary
+
+    | Severity | Count |
+    |----------|-------|
+    | Critical | X |
+    | Major | X |
+    | Minor | X |
+    | Info | X |
+
+    ### Critical Findings
+    [detailed list]
+
+    ### Major Findings
+    [detailed list]
+
+    ## Manual Testing Summary
+
+    | Metric | Count |
+    |--------|-------|
+    | Total Tests | X |
+    | Passed | X |
+    | Failed | X |
+    | Skipped | X |
+    | Blocked | X |
+
+    ### Test Results
+    [detailed table]
+
+    ## Sign-Off
+
+    - Manual Testing: [Approved/Not Approved] at [timestamp]
+    - Notes: [any notes from sign-off]
+
+    ## Recommendations
+
+    1. [recommendation 1]
+    2. [recommendation 2]
+    ...
+
+    ## Next Steps
+
+    - Run `/doit.testit` for automated test execution
+    - Address any CRITICAL or MAJOR findings before merge
+    ```
+
+11. **Generate Mermaid Visualizations** (FR-011, FR-012):
+
+    After collecting all review data, generate visual quality dashboards:
+
+    a. **Finding Distribution Pie Chart**:
+       - Count findings by severity (Critical, Major, Minor, Info)
+       - Generate pie chart showing distribution
+       - Add to review-report.md in Quality Overview section
+
+       ```mermaid
+       pie title Finding Distribution
+           "Critical" : 0
+           "Major" : 2
+           "Minor" : 5
+           "Info" : 3
+       ```
+
+       Insert using auto-generated markers:
+
+       ~~~markdown
+       ## Quality Overview
+
+       <!-- BEGIN:AUTO-GENERATED section="finding-distribution" -->
+       ```mermaid
+       pie title Finding Distribution
+           "Critical" : [count]
+           "Major" : [count]
+           "Minor" : [count]
+           "Info" : [count]
+       ```
+       <!-- END:AUTO-GENERATED -->
+       ~~~
+
+    b. **Test Results Visualization**:
+       - Count test results by status (Passed, Failed, Skipped, Blocked)
+       - Generate pie chart showing test outcomes
+       - Add to review-report.md in Manual Testing Summary section
+
+       ```mermaid
+       pie title Test Results
+           "Passed" : 8
+           "Failed" : 1
+           "Skipped" : 2
+           "Blocked" : 0
+       ```
+
+       Insert using auto-generated markers:
+
+       ~~~markdown
+       ## Test Results Overview
+
+       <!-- BEGIN:AUTO-GENERATED section="test-results" -->
+       ```mermaid
+       pie title Test Results
+           "Passed" : [count]
+           "Failed" : [count]
+           "Skipped" : [count]
+           "Blocked" : [count]
+       ```
+       <!-- END:AUTO-GENERATED -->
+       ~~~
+
+    c. **Conditional Generation**:
+       - If no findings: Show "No Issues Found" message instead of empty pie chart
+       - If no manual tests: Omit Test Results visualization entirely
+       - If all tests pass: Use green-themed success message
+
+    d. **Diagram Validation**:
+       - Verify mermaid syntax is valid
+       - Ensure all counts are non-negative integers
+       - Check that pie chart values sum to total count
+
+12. **Report**: Output path to review-report.md and summary of findings
+
+## Key Rules
+
+- Use absolute paths for all file operations
+- STOP on any CRITICAL finding that blocks further review
+- Present manual tests one at a time, wait for response
+- Generate review-report.md even if some tests are skipped
+- Include timestamps for audit trail
+
+---
+
+## Error Recovery
+
+### Missing Prerequisites
+
+Required files for review are not available.
+
+**ERROR** | If prerequisite files (spec.md, plan.md, tasks.md, or implementation files) are missing:
+
+1. Check which files are missing from the review prerequisites list
+2. If spec/plan/tasks are missing, run the appropriate command: `/doit.specit`, `/doit.planit`, or `/doit.taskit`
+3. If implementation files are missing, run `/doit.implementit` to complete remaining tasks
+4. Verify: `ls specs/*/spec.md specs/*/plan.md specs/*/tasks.md` confirms all required files exist
+
+> Prevention: Complete all implementation tasks before requesting a review
+
+If the above steps don't resolve the issue: manually verify which workflow steps were completed and re-run the missing ones.
+
+### Critical Findings Blocking Merge
+
+The review identified critical issues that must be fixed before the code can be merged.
+
+**ERROR** | If the review produces critical findings:
+
+1. Review each critical finding in the review output
+2. Address findings in priority order: security issues first, then correctness, then quality
+3. After fixing, re-run the specific checks that failed
+4. Re-request review: run `/doit.reviewit` again to verify all critical findings are resolved
+5. Verify: the review output shows no remaining critical findings
+
+> Prevention: Run `/doit.testit` before requesting review to catch issues early
+
+If the above steps don't resolve the issue: escalate to the team for a manual review of the contested findings.
+
+### Manual Test Failure
+
+A manual test scenario from the review checklist could not be verified.
+
+**WARNING** | If a manual test scenario fails during review:
+
+1. Identify which test scenario failed and the expected vs actual behavior
+2. Check if the failure is in the implementation or the test expectations
+3. If the implementation is wrong, fix it and re-test
+4. If the test expectations are wrong, update the acceptance scenarios in spec.md
+5. Verify: manually re-run the failing scenario and confirm it passes
+
+> Prevention: Review acceptance scenarios in spec.md before manual testing to set clear expectations
+
+If the above steps don't resolve the issue: document the failure in the review notes and create a follow-up issue for investigation.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (review approved, no critical issues)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌───────────────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                                │
+│  ● specit → ● planit → ● taskit → ● implementit → ● testit → ● reviewit → ○ checkin │
+└───────────────────────────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.checkin` to finalize and merge your changes.
+```
+
+### On Issues Found (changes requested)
+
+If the review found issues that need to be addressed:
+
+```markdown
+---
+
+## Next Steps
+
+┌───────────────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                                │
+│  ● specit → ● planit → ● taskit → ● implementit → ● testit → ◐ reviewit → ○ checkin │
+└───────────────────────────────────────────────────────────────────────────────────┘
+
+**Status**: [N] critical, [M] major issues found.
+
+**Recommended**: Run `/doit.implementit` to address the review feedback.
+
+After fixing issues, run `/doit.reviewit` again to verify.
+```
+

--- a/src/doit_cli/templates/skills/doit.roadmapit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.roadmapit/SKILL.md
@@ -1,0 +1,472 @@
+---
+name: doit.roadmapit
+description: Create or update the project roadmap with prioritized requirements, deferred functionality, and AI-suggested
+  enhancements.
+when_to_use: Use when the user wants to update the project roadmap, prioritize work, add or remove roadmap items, or reconcile
+  the roadmap with completed work.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[priority | feature description]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions (constitution is in context)
+- Review completed_roadmap for historical context (already loaded)
+- Identify connections to related specifications
+
+**Note**: Roadmap content is intentionally NOT loaded by context show for this command (to avoid circular reference when modifying). Read roadmap.md directly for modification.
+
+**DO NOT read these files again** (already in context above):
+
+- `.doit/memory/constitution.md` - principles are in context
+- `.doit/memory/completed_roadmap.md` - history is in context
+
+**Legitimate explicit reads** (for modification):
+
+- `.doit/memory/roadmap.md` - must read to modify
+- `README.md` - for project description (if no constitution)
+- `package.json` or `pyproject.toml` - for project metadata
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+This command creates or updates the project roadmap at `.doit/memory/roadmap.md`. The roadmap captures high-level requirements prioritized by business value, deferred items, and project vision.
+
+### 1. Parse Command Arguments
+
+Extract the operation and details from `$ARGUMENTS`:
+
+| Pattern | Operation | Example |
+|---------|-----------|---------|
+| `create [vision]` | Create new roadmap | `/doit.roadmapit create a task management app` |
+| `add [item]` | Add item to roadmap | `/doit.roadmapit add user authentication` |
+| `defer [item]` | Move item to deferred | `/doit.roadmapit defer social login` |
+| `reprioritize` | Review and change priorities | `/doit.roadmapit reprioritize` |
+| `sync-milestones` | Sync priorities to GitHub milestones | `/doit.roadmapit sync-milestones` |
+| `sync-milestones --dry-run` | Preview milestone sync | `/doit.roadmapit sync-milestones --dry-run` |
+| (empty or `update`) | Interactive update | `/doit.roadmapit` |
+
+If no arguments provided or unrecognized pattern, proceed to step 2 for detection.
+
+### 2. Check for Existing Roadmap
+
+Check if `.doit/memory/roadmap.md` exists:
+
+- **If NOT exists**: Proceed to Step 3 (Create Workflow)
+- **If exists**: Proceed to Step 4 (Update Workflow)
+
+### 3. Create Workflow (New Roadmap)
+
+#### 3.1 Ensure Directory Exists
+
+```bash
+mkdir -p .doit/memory
+```
+
+#### 3.2 Gather Project Context
+
+Use project context already loaded from `doit context show`:
+
+- Constitution principles and tech stack (already in context)
+- Completed roadmap history (already in context)
+
+If constitution is not available, read these files for project metadata:
+
+- `README.md` - Project description
+- `package.json` or `pyproject.toml` - Project metadata
+
+#### 3.3 Ask Clarifying Questions
+
+Present questions to establish roadmap foundation. Use the user's input (if provided) as context:
+
+**Question 1: Project Vision**
+> What is the primary goal or vision for this project?
+>
+> Based on your input "[USER_INPUT]", I understand the project is about [INTERPRETATION].
+>
+> Please confirm or provide a more detailed vision statement.
+
+**Question 2: Initial Priority Items**
+> What are the most critical features or requirements for your MVP?
+>
+> Suggested based on your description:
+> - [SUGGESTION_1]
+> - [SUGGESTION_2]
+>
+> Which of these are correct? What would you add or change?
+
+**Question 3: Known Constraints**
+> Are there any constraints or limitations to consider?
+>
+> Options:
+> A. Timeline constraints (specific deadline)
+> B. Technical constraints (must use specific tech)
+> C. Resource constraints (limited team/budget)
+> D. No significant constraints
+> E. Custom (please specify)
+
+#### 3.4 Build Roadmap Structure
+
+Using the gathered information, create the roadmap:
+
+1. Load template from `.doit/templates/roadmap-template.md`
+2. Replace `[PROJECT_NAME]` with project name from constitution or package metadata
+3. Replace `[DATE]` with current date
+4. Replace `[PROJECT_VISION]` with the confirmed vision statement
+5. Populate priority sections based on user's answers:
+   - Add confirmed critical items to P1
+   - Add important but not blocking items to P2
+   - Add nice-to-have items to P3/P4
+6. Leave Deferred Items empty for new roadmaps
+
+#### 3.5 Write Roadmap
+
+Write the populated roadmap to `.doit/memory/roadmap.md`
+
+#### 3.6 Offer Enhancement Suggestions
+
+After creating the roadmap, proceed to Step 6 (AI Suggestions).
+
+---
+
+### 4. Update Workflow (Existing Roadmap)
+
+#### 4.1 Load Current Roadmap
+
+Read `.doit/memory/roadmap.md` and parse:
+
+- Current vision statement
+- All items in P1, P2, P3, P4 sections with their status
+- All deferred items
+- Last updated date
+
+#### 4.2 Display Current State
+
+Show the user the current roadmap state:
+
+```markdown
+## Current Roadmap State
+
+**Vision**: [Current vision statement]
+**Last Updated**: [Date]
+
+### Active Items
+| Priority | Item | Feature Branch | Status |
+|----------|------|----------------|--------|
+| P1 | [item] | [branch-ref] | [ ] |
+| P2 | [item] | [branch-ref] | [ ] |
+...
+
+### Deferred Items
+| Item | Original Priority | Reason |
+|------|-------------------|--------|
+...
+```
+
+#### 4.3 Handle Specific Operations
+
+Based on the parsed operation from Step 1:
+
+**Add Operation (`add [item]`)**:
+1. Ask: "What priority should this item have? (P1/P2/P3/P4)"
+2. Ask: "What's the business rationale for this priority?"
+3. Ask: "Is there a feature branch reference? (e.g., `[###-feature-name]`)"
+4. Add the item to the appropriate section
+
+**Defer Operation (`defer [item]`)**:
+1. Search for the item in active sections
+2. If not found: List available items and ask user to select
+3. If found: Ask "What's the reason for deferring?"
+4. Move item to Deferred section with original priority and reason
+
+**Reprioritize Operation (`reprioritize`)**:
+1. List all active items with current priorities
+2. Ask: "Which items need priority changes?"
+3. For each item to change:
+   - Show current priority
+   - Ask for new priority (P1/P2/P3/P4)
+   - Ask for rationale for the change
+4. Update items in their new sections
+
+**Sync Milestones Operation (`sync-milestones` or `sync-milestones --dry-run`)**:
+
+1. Execute the milestone sync command:
+
+   ```bash
+   doit roadmapit sync-milestones [--dry-run]
+   ```
+
+2. The command will:
+   - Create GitHub milestones for each priority level (P1-P4) if they don't exist
+   - Assign roadmap epics to their corresponding priority milestones
+   - Display a summary of changes made
+3. After sync completes, show:
+   - Milestones created count
+   - Epics assigned count
+   - Link to view milestones on GitHub
+4. **Complete this operation** - Do not proceed to other steps
+
+**Interactive Update (no specific operation)**:
+1. Ask: "What would you like to do?"
+   - A. Add a new item
+   - B. Defer an item
+   - C. Reprioritize items
+   - D. Update the vision statement
+   - E. Mark an item as complete (moves to completed_roadmap.md)
+   - F. Sync priorities to GitHub milestones
+2. Execute the selected operation
+
+#### 4.4 Preserve Unmodified Content
+
+When updating the roadmap:
+
+- Keep all items not explicitly changed
+- Maintain existing rationales unless updated
+- Preserve feature branch references
+- Update only the `Last Updated` date
+
+#### 4.5 Write Updated Roadmap
+
+Write the modified roadmap back to `.doit/memory/roadmap.md`
+
+#### 4.6 Offer Enhancement Suggestions
+
+After updating, proceed to Step 6 (AI Suggestions).
+
+---
+
+### 5. Handle Edge Cases
+
+#### 5.1 Malformed Roadmap
+
+If existing roadmap cannot be parsed:
+
+1. Create backup: `mv .doit/memory/roadmap.md .doit/memory/roadmap.md.bak`
+2. Notify user: "The existing roadmap appears to be malformed. A backup has been created."
+3. Try to extract any readable content
+4. Offer to create fresh roadmap incorporating salvaged content
+
+#### 5.2 Item Not Found (for defer/update)
+
+If specified item cannot be found:
+
+1. List all current items in a table
+2. Ask user to select from the list or provide exact item text
+3. Use fuzzy matching to suggest closest matches
+
+#### 5.3 Conflicting Priorities
+
+If user assigns multiple P1 items:
+
+1. Show warning: "You have [N] P1 items. P1 should be reserved for truly critical items."
+2. Ask: "Would you like to compare these items to determine which is most critical?"
+3. If yes, present pairwise comparison for each P1 item
+
+---
+
+### 6. AI Enhancement Suggestions
+
+After any create or update operation, analyze the roadmap and project context to suggest enhancements.
+
+#### 6.1 Gather Context
+
+Use context already loaded from `doit context show`:
+
+- Constitution principles (already in context)
+- Completed roadmap history (already in context)
+- Current roadmap items and gaps (from roadmap file read in step 4.1)
+
+#### 6.2 Generate Suggestions
+
+Based on context, generate 2-5 complementary feature suggestions:
+
+```markdown
+## Enhancement Suggestions
+
+Based on your roadmap and project context, here are some features you might consider:
+
+### Suggestion 1: [Feature Name]
+**Rationale**: [Why this complements existing items]
+**Suggested Priority**: P[N]
+**Aligns with**: [Related existing item or principle]
+
+### Suggestion 2: [Feature Name]
+...
+
+---
+
+**Actions**:
+- Type the suggestion number to add it (e.g., "1" or "1, 3")
+- Type "skip" to finish without adding suggestions
+- Type "modify [N]" to customize a suggestion before adding
+```
+
+#### 6.3 Handle Suggestion Response
+
+- If user selects suggestions: Add them to the appropriate priority sections
+- If user modifies: Apply customizations then add
+- If user skips: Complete without changes
+
+---
+
+### 7. Completion Report
+
+Output a summary of changes:
+
+```markdown
+## Roadmap Update Complete
+
+**File**: `.doit/memory/roadmap.md`
+**Operation**: [Create/Add/Defer/Reprioritize]
+**Date**: [Current date]
+
+### Changes Made
+- [List of specific changes]
+
+### Current Statistics
+| Priority | Count |
+|----------|-------|
+| P1 | [N] |
+| P2 | [N] |
+| P3 | [N] |
+| P4 | [N] |
+| Deferred | [N] |
+
+### Next Steps
+- Run `/doit.specit` to create specs for top priority items
+- Run `/doit.roadmapit` again to continue updating
+- Review completed items in `.doit/memory/completed_roadmap.md`
+```
+
+---
+
+## Key Rules
+
+- Always preserve existing content when updating
+- Ask clarifying questions before making changes
+- Provide AI suggestions after every operation
+- Use feature branch references `[###-feature-name]` for traceability
+- Maintain maximum 3-5 P1 items (truly critical only)
+- Back up malformed roadmaps before recreating
+
+---
+
+## Error Recovery
+
+### GitHub API Authentication Failure
+
+The roadmap could not be synced because GitHub authentication is invalid.
+
+**ERROR** | If GitHub API calls fail during roadmap sync:
+
+1. Check your authentication: `gh auth status`
+2. If expired or invalid, re-authenticate: `gh auth login`
+3. Verify repository access: `gh repo view`
+4. Retry: re-run `/doit.roadmapit`
+5. Verify: `gh issue list --limit 5` confirms API access is working
+
+> Prevention: Run `gh auth status` before starting roadmap operations
+
+If the above steps don't resolve the issue: proceed with local-only roadmap updates — GitHub sync can be done later.
+
+### Merge Conflict in Roadmap File
+
+The roadmap file has conflicting changes from concurrent edits.
+
+**ERROR** | If the roadmap file has merge conflicts:
+
+1. Open the roadmap file and look for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+2. Resolve conflicts by choosing the correct content for each section
+3. After resolving, stage the file: `git add .doit/memory/roadmap.md`
+4. Verify: `cat .doit/memory/roadmap.md | grep -c "<<<<<<"` returns 0
+
+> Prevention: Pull latest changes before editing the roadmap: `git pull`
+
+If the above steps don't resolve the issue: back up your changes, reset the file to the remote version, and manually re-apply your updates.
+
+### Priority Conflict or Duplicate Items
+
+The roadmap contains duplicate entries or conflicting priority assignments.
+
+**WARNING** | If duplicate or conflicting roadmap items are detected:
+
+1. Review the roadmap for duplicate entries: check for items with similar names
+2. Merge duplicates by combining their descriptions and keeping the higher priority
+3. Resolve priority conflicts by reviewing the project goals and timeline
+4. Re-run `/doit.roadmapit` to validate the updated roadmap
+5. Verify: no duplicate items appear in the roadmap output
+
+> Prevention: Review existing roadmap items before adding new ones to avoid duplicates
+
+If the above steps don't resolve the issue: manually edit the roadmap file to remove duplicates and set clear priorities.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (roadmap created or updated)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+**Roadmap updated!**
+
+**Recommended**: Run `/doit.specit [top priority item]` to create a specification for your highest priority feature.
+
+**Alternative**: Run `/doit.roadmapit add [item]` to add more items to the roadmap.
+```
+
+### On Item Added
+
+If a new item was added to the roadmap:
+
+```markdown
+---
+
+## Next Steps
+
+**Item added to roadmap!**
+
+**Recommended**: Run `/doit.specit [item description]` to create a specification for this item.
+
+**Alternative**: Run `/doit.roadmapit reprioritize` to review and adjust priorities.
+```

--- a/src/doit_cli/templates/skills/doit.taskit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.taskit/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: doit.taskit
+description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+when_to_use: Use when the user wants to break an implementation plan into an actionable, dependency-ordered task list in tasks.md.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[feature-name]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+- Use tech stack info for accurate file paths and framework-specific tasks (already in context)
+
+**DO NOT read these files again** (already in context above):
+
+- `.doit/memory/constitution.md` - principles are in context
+- `.doit/memory/tech-stack.md` - tech decisions are in context
+- `.doit/memory/roadmap.md` - priorities are in context
+
+**Legitimate explicit reads** (NOT in context show):
+
+- `specs/{feature}/plan.md` - detailed implementation plan
+- `specs/{feature}/spec.md` - user stories with priorities
+- `specs/{feature}/data-model.md` - entities to map
+- `specs/{feature}/contracts/*.yaml` - API endpoints to map
+- `specs/{feature}/research.md` - decisions for setup tasks
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. **Setup**: Run `.doit/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Use tech stack from loaded context (already available from doit context show)
+   - Load plan.md and extract project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map endpoints to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.doit/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Generate Mermaid Visualizations** (FR-008, FR-009, FR-010):
+
+   After generating the task list, create visual diagrams to show execution order and timelines:
+
+   a. **Task Dependencies Flowchart**:
+      - Parse all generated tasks and their dependencies
+      - Identify parallel tasks (marked with [P])
+      - Group tasks by phase using subgraphs
+      - Generate flowchart showing task execution order
+      - Use `&` syntax for parallel tasks: `T003 --> T004 & T005`
+      - Replace content in `<!-- BEGIN:AUTO-GENERATED section="task-dependencies" -->` markers
+
+      ```mermaid
+      flowchart TD
+          subgraph "Phase 1: Setup"
+              T001[T001: Project init]
+          end
+
+          subgraph "Phase 2: Foundation"
+              T002[T002: Dependencies]
+              T003[T003: Core setup]
+          end
+
+          subgraph "Phase 3: US1"
+              T004[T004: Model A]
+              T005[T005: Model B]
+              T006[T006: Service]
+          end
+
+          T001 --> T002 --> T003
+          T003 --> T004 & T005
+          T004 & T005 --> T006
+      ```
+
+   b. **Phase Timeline Gantt Chart**:
+      - Extract phases and their task counts
+      - Estimate duration based on task complexity (1 task ≈ 0.5-1 day)
+      - Generate gantt chart showing phase timeline
+      - Use `after` syntax for dependencies
+      - Replace content in `<!-- BEGIN:AUTO-GENERATED section="phase-timeline" -->` markers
+
+      ```mermaid
+      gantt
+          title Implementation Phases
+          dateFormat YYYY-MM-DD
+
+          section Phase 1: Setup
+          Project initialization    :a1, 2024-01-01, 1d
+
+          section Phase 2: Foundation
+          Core infrastructure       :b1, after a1, 2d
+
+          section Phase 3: US1 (P1)
+          User Story 1 implementation :c1, after b1, 3d
+
+          section Phase 4: US2 (P2)
+          User Story 2 implementation :d1, after c1, 2d
+
+          section Final: Polish
+          Cross-cutting concerns    :e1, after d1, 1d
+      ```
+
+   c. **Parallel Task Detection**:
+      - Scan all tasks for [P] markers
+      - Group consecutive parallel tasks for diagram optimization
+      - In flowchart: Connect parallel tasks with `&` syntax
+      - Add legend note: "[P] = Can run in parallel"
+
+   d. **Diagram Validation**:
+      - Verify mermaid syntax is valid
+      - Check task count per subgraph (max 15 per phase)
+      - If exceeding limits, group smaller tasks into summary nodes
+      - Ensure all task IDs in diagram match task list
+
+6. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+7. **GitHub Issue Integration**:
+   - Check for `--skip-issues` in $ARGUMENTS - if present, skip issue creation
+   - Detect GitHub remote: `git remote get-url origin`
+   - If GitHub remote found and not skipped:
+     - For each generated task, create a GitHub Task issue using the task.yml template
+     - Find parent Feature issues by searching for feature labels matching current spec
+     - Link Task issues to parent Feature using "Part of Feature #XXX" in body
+     - Add phase label (e.g., "Phase 3 - Core Implementation")
+     - Add effort estimate if extractable from task description
+   - If GitHub unavailable or API fails: Log warning and continue without issues
+   - Report: Number of issues created, any linking errors
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Endpoints/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each contract/endpoint → to the user story it serves
+   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns
+
+---
+
+## Error Recovery
+
+### Missing Implementation Plan
+
+The plan needed for task generation was not found.
+
+**ERROR** | If `plan.md` is not found in the feature specs directory:
+
+1. Check if the plan exists: `ls specs/*/plan.md`
+2. If missing, create it: run `/doit.planit` to generate an implementation plan
+3. If the plan exists but in a different directory, verify your feature branch: `git branch --show-current`
+4. Verify: `cat specs/{feature}/plan.md | head -5` shows the plan header
+
+> Prevention: Always run `/doit.planit` before `/doit.taskit`
+
+If the above steps don't resolve the issue: verify the feature branch name matches the spec directory name.
+
+### Missing Feature Specification
+
+The specification file needed for user story extraction was not found.
+
+**ERROR** | If `spec.md` is not found:
+
+1. Check if the spec exists: `ls specs/*/spec.md`
+2. If missing, the full workflow must be followed: run `/doit.specit {feature}` first
+3. If found in a different directory, ensure you're on the correct branch
+4. Verify: `cat specs/{feature}/spec.md | head -5` shows the spec header
+
+> Prevention: Follow the workflow order: specit → planit → taskit
+
+If the above steps don't resolve the issue: run `/doit.specit` to create the specification, then `/doit.planit`, then retry `/doit.taskit`.
+
+### Circular Dependency Detected
+
+Tasks have dependencies that form a cycle, preventing a valid execution order.
+
+**ERROR** | If task generation detects circular dependencies:
+
+1. Review the dependency graph in the task output for the cycle
+2. Identify which task dependency should be broken (typically the least critical one)
+3. Restructure the task to remove the circular reference — consider splitting the task or reordering
+4. Re-run `/doit.taskit` to regenerate with the corrected dependencies
+5. Verify: the dependency flowchart in tasks.md shows no cycles
+
+If the above steps don't resolve the issue: simplify the task breakdown by merging interdependent tasks into a single task.
+
+### Task Count Exceeds Limit
+
+The generated task list is unusually large, suggesting the feature scope may be too broad.
+
+**WARNING** | If an excessive number of tasks are generated:
+
+1. Review the task list for duplicate or overly granular tasks
+2. Check if the feature scope in spec.md is well-bounded
+3. Consider splitting the feature into smaller features with separate specs
+4. Re-run `/doit.taskit` after adjusting the scope
+5. Verify: the task count is reasonable for the feature size (typically 10-30 tasks)
+
+If the above steps don't resolve the issue: consult the roadmap to determine if the feature should be broken into multiple releases.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (tasks generated)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ● planit → ● taskit → ○ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.implementit` to start executing the implementation tasks.
+```

--- a/src/doit_cli/templates/skills/doit.testit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.testit/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: doit.testit
+description: Execute automated tests and generate test reports with requirement mapping
+when_to_use: Use when the user wants to run the automated test suite and generate a test report mapped to requirements and
+  user stories.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[test filter or feature]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+1. **Setup**: Run `.doit/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+
+2. **Load test context**:
+   - **REQUIRED**: Read spec.md for requirements (FR-XXX identifiers)
+   - **REQUIRED**: Read tasks.md for test file locations
+   - **IF EXISTS**: Read plan.md for test strategy and coverage goals
+   - **IF EXISTS**: Read contracts/ for API test expectations
+
+3. **Detect test framework**:
+   - Check for test configuration files:
+     - **Python**: pytest.ini, pyproject.toml [tool.pytest], setup.cfg, conftest.py
+     - **JavaScript/TypeScript**: jest.config.js/ts, vitest.config.js/ts, mocha.opts, .mocharc.*
+     - **Java**: pom.xml (maven-surefire), build.gradle (test task)
+     - **Go**: *_test.go files present
+     - **Ruby**: Rakefile, .rspec, spec/ directory
+     - **C#/.NET**: *.csproj with test SDK, xunit, nunit references
+     - **Rust**: Cargo.toml with [dev-dependencies] test crates
+   - Determine test command:
+     - pytest: `pytest -v --tb=short`
+     - jest: `npm test` or `npx jest`
+     - vitest: `npm test` or `npx vitest run`
+     - go: `go test ./...`
+     - maven: `mvn test`
+     - gradle: `./gradlew test`
+     - dotnet: `dotnet test`
+     - cargo: `cargo test`
+
+4. **Execute test suite**:
+   - Run detected test command
+   - Capture stdout/stderr
+   - Parse test results:
+     - Total tests run
+     - Passed tests
+     - Failed tests
+     - Skipped tests
+     - Test duration
+   - Capture any coverage reports if generated
+
+5. **Generate test report**:
+
+   ```text
+   ## Automated Test Results
+
+   **Framework**: [detected framework]
+   **Command**: [test command used]
+   **Duration**: [total time]
+
+   ### Summary
+   | Metric | Count |
+   |--------|-------|
+   | Total | X |
+   | Passed | X |
+   | Failed | X |
+   | Skipped | X |
+
+   ### Failed Tests
+   | Test | File | Error |
+   |------|------|-------|
+   | test_name | path/to/test.py | AssertionError: ... |
+
+   ### Coverage (if available)
+   | File | Coverage |
+   |------|----------|
+   | src/module.py | 85% |
+   ```
+
+6. **Map tests to requirements**:
+   - Parse test names and docstrings for FR-XXX references
+   - Match tests to requirements from spec.md
+   - Generate requirement coverage matrix:
+
+     ```text
+     ## Requirement Coverage
+
+     | Requirement | Description | Tests | Status |
+     |-------------|-------------|-------|--------|
+     | FR-001 | User login | test_login, test_auth | COVERED |
+     | FR-002 | Password reset | - | NOT COVERED |
+     | FR-003 | Session timeout | test_session_expiry | COVERED |
+     ```
+
+   - Calculate coverage percentage: (covered requirements / total requirements) * 100
+
+7. **Generate manual testing checklist**:
+   - Extract acceptance criteria from spec.md that cannot be automated
+   - Create checklist format:
+
+     ```text
+     ## Manual Testing Checklist
+
+     ### UI/UX Tests
+     - [ ] MT-001: Verify login form displays correctly on mobile
+     - [ ] MT-002: Verify error messages are user-friendly
+
+     ### Integration Tests
+     - [ ] MT-003: Verify third-party payment processing
+     - [ ] MT-004: Verify email notifications are received
+
+     ### Edge Cases
+     - [ ] MT-005: Verify behavior with slow network
+     - [ ] MT-006: Verify recovery from server timeout
+     ```
+
+8. **Record manual test results**:
+   - If $ARGUMENTS contains `--manual`:
+     - Present each manual test item
+     - Ask for PASS/FAIL/SKIP result
+     - Record notes for failed tests
+     - Track completion progress
+   - Otherwise, output checklist for later completion
+
+9. **Generate test-report.md** in FEATURE_DIR:
+
+   ```markdown
+   # Test Report: [Feature Name]
+
+   **Date**: [timestamp]
+   **Branch**: [current branch]
+   **Test Framework**: [detected]
+
+   ## Automated Tests
+
+   ### Execution Summary
+   | Metric | Value |
+   |--------|-------|
+   | Total Tests | X |
+   | Passed | X |
+   | Failed | X |
+   | Skipped | X |
+   | Duration | Xs |
+
+   ### Failed Tests Detail
+   [list of failed tests with errors]
+
+   ### Code Coverage
+   [coverage summary if available]
+
+   ## Requirement Coverage
+
+   | Requirement | Tests | Status |
+   |-------------|-------|--------|
+   | FR-XXX | test_xxx | COVERED |
+   ...
+
+   **Coverage**: X/Y requirements (Z%)
+
+   ## Manual Testing
+
+   ### Checklist Status
+   | Test ID | Description | Status |
+   |---------|-------------|--------|
+   | MT-001 | ... | PENDING |
+   ...
+
+   ## Recommendations
+
+   1. [Fix failing tests before merge]
+   2. [Add tests for uncovered requirements]
+   3. [Complete manual testing checklist]
+
+   ## Next Steps
+
+   - Fix any failing tests
+   - Complete manual testing if not done
+   - Run `/doit.checkin` when all tests pass
+   ```
+
+10. **Report**: Output path to test-report.md and summary:
+    - Automated test pass rate
+    - Requirement coverage percentage
+    - Manual test completion status
+    - Overall readiness for merge
+
+## Key Rules
+
+- Use absolute paths for all file operations
+- If no test framework detected, report and suggest adding tests
+- Continue generating report even if some tests fail
+- Preserve test output for debugging
+- Map requirements using FR-XXX pattern matching in test names/docstrings
+
+---
+
+## Error Recovery
+
+### No Test Framework Detected
+
+The test runner could not find a compatible testing framework in the project.
+
+**ERROR** | If no test framework is detected:
+
+1. Check if test dependencies are installed: `pip list | grep pytest` (or equivalent for your framework)
+2. If missing, install the test framework: `pip install pytest` (or as specified in dev dependencies)
+3. Check if test configuration exists: `ls pytest.ini pyproject.toml setup.cfg` for pytest config sections
+4. Verify: `pytest --version` confirms the framework is available
+
+> Prevention: Ensure test dependencies are listed in dev requirements and installed before running tests
+
+If the above steps don't resolve the issue: manually specify the test command in the template or project configuration.
+
+### Test Execution Failure
+
+One or more tests failed during the test run.
+
+**ERROR** | If tests fail during execution:
+
+1. Review the failure output to identify failing tests and error messages
+2. Run the failing test in isolation for detailed output: `pytest tests/path/to/failing_test.py -x -v --tb=long`
+3. Check if the failure is in your changes or pre-existing: `git stash && pytest tests/ && git stash pop`
+4. Fix the failing code or test, then re-run: `pytest tests/ -x --tb=short`
+5. Verify: `pytest tests/ --tb=short` shows all tests passing
+
+If the above steps don't resolve the issue: run `/doit.reviewit` to get a code review that may identify the root cause.
+
+### Missing Test Dependencies
+
+Required packages for testing are not installed.
+
+**ERROR** | If test dependencies are missing:
+
+1. Check for a requirements file: `ls requirements*.txt **/requirements*.txt setup.py pyproject.toml`
+2. Install dev dependencies: `pip install -e ".[dev]"` or `pip install -r requirements-dev.txt`
+3. If specific packages are missing, install them: `pip install {package-name}`
+4. Verify: `pip list | grep {package-name}` confirms installation
+
+> Prevention: Run `pip install -e ".[dev]"` at the start of each development session
+
+If the above steps don't resolve the issue: check if the dependency version is compatible with your Python version.
+
+### Coverage Threshold Not Met
+
+Tests pass but code coverage is below the expected threshold.
+
+**WARNING** | If coverage is below the target threshold:
+
+1. Review the coverage report to identify uncovered files and lines
+2. Check which files have the lowest coverage: review the coverage output or HTML report
+3. Add tests for the most critical uncovered paths first
+4. Re-run with coverage: `pytest tests/ --cov=src/ --cov-report=term-missing`
+5. Verify: coverage percentage meets or exceeds the project threshold
+
+If the above steps don't resolve the issue: document the coverage gap in the review notes and address it in a follow-up task.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (all tests pass)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                      │
+│  ● specit → ● planit → ● taskit → ● implementit → ● testit → ○ checkin │
+└─────────────────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.reviewit` for a code review before finalizing.
+
+**Alternative**: Run `/doit.checkin` to merge your changes if code review is not needed.
+```
+
+### On Failure (tests fail)
+
+If some tests fail:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                                      │
+│  ● specit → ● planit → ● taskit → ● implementit → ◐ testit → ○ checkin │
+└─────────────────────────────────────────────────────────────────────────┘
+
+**Status**: N tests failed out of M total.
+
+**Recommended**: Run `/doit.implementit` to fix the failing tests.
+```
+

--- a/tests/contract/test_bundled_skills.py
+++ b/tests/contract/test_bundled_skills.py
@@ -1,0 +1,101 @@
+"""Contract: every shipped skill under templates/skills/ meets the April 2026 spec.
+
+Parametrized over every skill directory found. A new skill gets checked
+automatically once its directory exists; no test file edit required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doit_cli.models.skill_template import (
+    DESCRIPTION_CHAR_BUDGET,
+    SKILL_MAX_LINES,
+    SkillTemplate,
+)
+from doit_cli.services.skill_reader import SkillReader
+
+
+def _bundled_skills() -> list[SkillTemplate]:
+    return SkillReader().scan_bundled_skills()
+
+
+SKILLS = _bundled_skills()
+
+
+@pytest.mark.parametrize("skill", SKILLS, ids=lambda s: s.name)
+class TestShippedSkillFrontmatter:
+    """Every bundled skill obeys the April 2026 SKILL.md contract."""
+
+    def test_required_fields_present(self, skill: SkillTemplate) -> None:
+        assert skill.name, "frontmatter missing `name`"
+        assert skill.description, "frontmatter missing `description`"
+
+    def test_recommended_fields_present(self, skill: SkillTemplate) -> None:
+        assert skill.when_to_use, (
+            f"{skill.name}: missing `when_to_use` — Claude needs trigger "
+            f"keywords to know when to load the skill automatically."
+        )
+        assert skill.allowed_tools, (
+            f"{skill.name}: missing `allowed-tools` — without it, Claude "
+            f"will prompt for every tool use."
+        )
+
+    def test_no_claude_frontmatter_leaks(self, skill: SkillTemplate) -> None:
+        """handoffs and effort are doit-only / default-inherited and must not ship."""
+        assert "handoffs" not in skill.frontmatter, (
+            f"{skill.name}: frontmatter has `handoffs:` — that field isn't "
+            f"native to Claude Code; inline a 'Next Steps' section instead."
+        )
+        assert "effort" not in skill.frontmatter, (
+            f"{skill.name}: frontmatter hard-codes `effort:` — let it "
+            f"inherit from the session."
+        )
+
+    def test_under_line_budget(self, skill: SkillTemplate) -> None:
+        assert skill.skill_md_line_count <= SKILL_MAX_LINES, (
+            f"{skill.name}: SKILL.md is {skill.skill_md_line_count} lines "
+            f"(budget is {SKILL_MAX_LINES}); move detail into supporting files."
+        )
+
+    def test_under_description_budget(self, skill: SkillTemplate) -> None:
+        assert skill.description_char_count <= DESCRIPTION_CHAR_BUDGET, (
+            f"{skill.name}: description+when_to_use is "
+            f"{skill.description_char_count} chars (budget is "
+            f"{DESCRIPTION_CHAR_BUDGET})."
+        )
+
+    def test_validate_returns_no_issues(self, skill: SkillTemplate) -> None:
+        """SkillTemplate.validate() catches all the above plus name length."""
+        assert skill.validate() == []
+
+
+def test_every_command_has_a_skill_counterpart() -> None:
+    """For every doit.*.md command template, ensure a skill dir exists.
+
+    This catches templates we forgot to migrate. Pilot phases will have
+    gaps; when the gap closes, remove the `xfail` markers.
+    """
+    commands_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src" / "doit_cli" / "templates" / "commands"
+    )
+    command_names = {p.stem for p in commands_dir.glob("doit.*.md")}
+    skill_names = {s.name for s in SKILLS}
+
+    # Record the migration status so the test fails loud when someone
+    # adds a new command template without a skill counterpart.
+    not_yet_migrated = command_names - skill_names
+    expected_not_yet = {
+        "doit.specit",
+        "doit.researchit",
+        "doit.documentit",
+        "doit.scaffoldit",
+    }
+    assert not_yet_migrated == expected_not_yet, (
+        f"Migration delta changed. Previously unmigrated: {expected_not_yet}. "
+        f"Now unmigrated: {not_yet_migrated}. "
+        f"Either finish the migration or update this test's expected set."
+    )

--- a/tests/unit/test_skill_reader.py
+++ b/tests/unit/test_skill_reader.py
@@ -1,0 +1,115 @@
+"""Tests for SkillReader (bundled skills discovery)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doit_cli.models.skill_template import SkillTemplate
+from doit_cli.services.skill_reader import SkillReader
+
+
+class TestSkillReader:
+    """Discovery of skill directories bundled with the package."""
+
+    def _fixture_reader(self, tmp_path: Path) -> SkillReader:
+        """Create a SkillReader rooted at a tmp templates/skills layout."""
+        skills_root = tmp_path / "templates" / "skills"
+        skills_root.mkdir(parents=True)
+        return SkillReader(package_root=tmp_path)
+
+    def _write(self, reader: SkillReader, name: str, fm_extra: str = "", body: str = "x") -> Path:
+        skill_dir = reader.skills_root / name
+        skill_dir.mkdir()
+        content = f"---\nname: {name}\ndescription: Test skill.\n{fm_extra}---\n\n{body}\n"
+        (skill_dir / "SKILL.md").write_text(content)
+        return skill_dir
+
+    def test_empty_root_returns_empty_list(self, tmp_path: Path) -> None:
+        reader = self._fixture_reader(tmp_path)
+        assert reader.scan_bundled_skills() == []
+
+    def test_missing_root_returns_empty_list(self, tmp_path: Path) -> None:
+        reader = SkillReader(package_root=tmp_path / "does-not-exist")
+        assert reader.scan_bundled_skills() == []
+
+    def test_discovers_multiple_skills(self, tmp_path: Path) -> None:
+        reader = self._fixture_reader(tmp_path)
+        self._write(reader, "doit.a")
+        self._write(reader, "doit.b")
+        self._write(reader, "doit.c")
+
+        skills = reader.scan_bundled_skills()
+        assert [s.name for s in skills] == ["doit.a", "doit.b", "doit.c"]
+
+    def test_skips_underscore_prefixed_dirs(self, tmp_path: Path) -> None:
+        """`_shared/` etc. are reserved for fragment files, not skills."""
+        reader = self._fixture_reader(tmp_path)
+        shared = reader.skills_root / "_shared"
+        shared.mkdir()
+        (shared / "fragment.md").write_text("# fragment\n")
+
+        self._write(reader, "doit.ok")
+
+        skills = reader.scan_bundled_skills()
+        assert [s.name for s in skills] == ["doit.ok"]
+
+    def test_skips_dirs_without_skill_md(self, tmp_path: Path) -> None:
+        reader = self._fixture_reader(tmp_path)
+        empty = reader.skills_root / "doit.empty"
+        empty.mkdir()
+        self._write(reader, "doit.good")
+
+        skills = reader.scan_bundled_skills()
+        assert [s.name for s in skills] == ["doit.good"]
+
+    def test_continues_past_parse_errors(self, tmp_path: Path) -> None:
+        """A malformed SKILL.md must not crash the whole scan."""
+        reader = self._fixture_reader(tmp_path)
+        bad = reader.skills_root / "doit.bad"
+        bad.mkdir()
+        (bad / "SKILL.md").write_text("---\nname: doit.bad\n")  # unclosed fm
+
+        self._write(reader, "doit.good")
+
+        skills = reader.scan_bundled_skills()
+        assert [s.name for s in skills] == ["doit.good"]
+
+    def test_get_skill_by_name(self, tmp_path: Path) -> None:
+        reader = self._fixture_reader(tmp_path)
+        self._write(reader, "doit.x")
+        self._write(reader, "doit.y")
+
+        found = reader.get_skill("doit.x")
+        assert found is not None
+        assert isinstance(found, SkillTemplate)
+        assert found.name == "doit.x"
+
+    def test_get_skill_returns_none_when_absent(self, tmp_path: Path) -> None:
+        reader = self._fixture_reader(tmp_path)
+        self._write(reader, "doit.x")
+        assert reader.get_skill("doit.missing") is None
+
+
+class TestBundledConstitutionPilot:
+    """Integration smoke test: the shipped constitution skill parses cleanly."""
+
+    def test_constitution_skill_exists_and_parses(self) -> None:
+        reader = SkillReader()  # points at real src/doit_cli/templates/skills
+        skill = reader.get_skill("doit.constitution")
+        if skill is None:
+            pytest.skip("constitution skill not yet bundled in this build")
+
+        assert skill.description
+        assert skill.when_to_use
+        assert skill.allowed_tools
+        # Frontmatter hygiene the plan enforces
+        assert "handoffs" not in skill.frontmatter
+        assert "effort" not in skill.frontmatter
+        # Must stay under the 500-line SKILL.md budget
+        assert skill.skill_md_line_count <= 500, (
+            f"SKILL.md has {skill.skill_md_line_count} lines; move detail into supporting files."
+        )
+        # Description budget per Claude docs
+        assert skill.description_char_count <= 1536

--- a/tests/unit/test_skill_template.py
+++ b/tests/unit/test_skill_template.py
@@ -1,0 +1,141 @@
+"""Tests for SkillTemplate parsing and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doit_cli.models.skill_template import (
+    DESCRIPTION_CHAR_BUDGET,
+    SKILL_MAX_LINES,
+    SkillTemplate,
+)
+
+
+def _write_skill(tmp_path: Path, name: str, skill_md: str, extra: dict[str, str] | None = None) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(skill_md)
+    if extra:
+        for rel, contents in extra.items():
+            p = skill_dir / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(contents)
+    return skill_dir
+
+
+class TestSkillTemplateParsing:
+    """Frontmatter + body splitting."""
+
+    def test_parses_minimal_skill(self, tmp_path: Path) -> None:
+        src = _write_skill(
+            tmp_path,
+            "doit.simple",
+            "---\nname: doit.simple\ndescription: Minimal pilot skill.\n---\n\nHello.\n",
+        )
+        skill = SkillTemplate.from_directory(src)
+
+        assert skill.name == "doit.simple"
+        assert skill.description == "Minimal pilot skill."
+        assert skill.body.strip() == "Hello."
+        assert skill.when_to_use == ""
+
+    def test_parses_all_declared_frontmatter(self, tmp_path: Path) -> None:
+        fm = """---
+name: doit.full
+description: Everything populated.
+when_to_use: When the user asks foo.
+allowed-tools: Read Write
+argument-hint: "[issue-number]"
+model: sonnet
+disable-model-invocation: true
+user-invocable: false
+---
+
+Body.
+"""
+        src = _write_skill(tmp_path, "doit.full", fm)
+        skill = SkillTemplate.from_directory(src)
+
+        assert skill.when_to_use == "When the user asks foo."
+        assert skill.allowed_tools == "Read Write"
+        assert skill.argument_hint == "[issue-number]"
+        assert skill.model == "sonnet"
+        assert skill.disable_model_invocation is True
+        assert skill.user_invocable is False
+
+    def test_flattens_list_form_allowed_tools(self, tmp_path: Path) -> None:
+        fm = """---
+name: doit.list-tools
+description: YAML list form.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+---
+
+x
+"""
+        src = _write_skill(tmp_path, "doit.list-tools", fm)
+        skill = SkillTemplate.from_directory(src)
+        assert skill.allowed_tools == "Read Write Edit"
+
+    def test_discovers_supporting_files(self, tmp_path: Path) -> None:
+        src = _write_skill(
+            tmp_path,
+            "doit.big",
+            "---\nname: doit.big\ndescription: Has supporting files.\n---\n\nBody.\n",
+            extra={
+                "reference.md": "# Reference\n",
+                "examples/sample.md": "# Example\n",
+            },
+        )
+        skill = SkillTemplate.from_directory(src)
+        names = {p.name for p in skill.supporting_files}
+        assert names == {"reference.md", "sample.md"}
+
+    def test_raises_on_missing_directory(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            SkillTemplate.from_directory(tmp_path / "nope")
+
+    def test_raises_on_missing_skill_md(self, tmp_path: Path) -> None:
+        (tmp_path / "empty").mkdir()
+        with pytest.raises(FileNotFoundError, match=r"missing SKILL\.md"):
+            SkillTemplate.from_directory(tmp_path / "empty")
+
+    def test_raises_on_unclosed_frontmatter(self, tmp_path: Path) -> None:
+        src = _write_skill(tmp_path, "doit.bad", "---\nname: doit.bad\n")
+        with pytest.raises(ValueError, match="closing delimiter"):
+            SkillTemplate.from_directory(src)
+
+    def test_raises_on_missing_required_field(self, tmp_path: Path) -> None:
+        src = _write_skill(tmp_path, "doit.missing", "---\nname: doit.missing\n---\n\nBody\n")
+        with pytest.raises(ValueError, match="description"):
+            SkillTemplate.from_directory(src)
+
+
+class TestSkillTemplateValidation:
+    """The validate() lint — counts + name constraints."""
+
+    def _make(self, tmp_path: Path, body: str, when_to_use: str = "") -> SkillTemplate:
+        fm_when = f'when_to_use: "{when_to_use}"\n' if when_to_use else ""
+        raw = f"---\nname: doit.v\ndescription: ok\n{fm_when}---\n\n{body}"
+        src = _write_skill(tmp_path, "doit.v", raw)
+        return SkillTemplate.from_directory(src)
+
+    def test_clean_skill_has_no_warnings(self, tmp_path: Path) -> None:
+        skill = self._make(tmp_path, "one line\n")
+        assert skill.validate() == []
+
+    def test_flags_oversized_description(self, tmp_path: Path) -> None:
+        long_when = "x" * (DESCRIPTION_CHAR_BUDGET + 10)
+        skill = self._make(tmp_path, "body\n", when_to_use=long_when)
+        issues = skill.validate()
+        assert any("description+when_to_use" in i for i in issues)
+
+    def test_flags_oversized_skill_md(self, tmp_path: Path) -> None:
+        body = "\n".join(["filler"] * (SKILL_MAX_LINES + 5)) + "\n"
+        skill = self._make(tmp_path, body)
+        issues = skill.validate()
+        assert any(str(SKILL_MAX_LINES) in i for i in issues)

--- a/tests/unit/test_skill_writer.py
+++ b/tests/unit/test_skill_writer.py
@@ -1,0 +1,89 @@
+"""Tests for SkillWriter (copies skill dirs into a target project)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from doit_cli.models.skill_template import SkillTemplate
+from doit_cli.services.skill_writer import SkillWriter
+
+
+def _make_source_skill(root: Path, name: str, with_extras: bool = False) -> SkillTemplate:
+    src = root / name
+    src.mkdir()
+    (src / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test.\n---\n\nBody.\n"
+    )
+    if with_extras:
+        (src / "reference.md").write_text("# reference\n")
+        examples = src / "examples"
+        examples.mkdir()
+        (examples / "sample.md").write_text("# sample\n")
+    return SkillTemplate.from_directory(src)
+
+
+class TestSkillWriter:
+    def test_writes_skill_md_and_supporting_files(self, tmp_path: Path) -> None:
+        source_root = tmp_path / "src"
+        source_root.mkdir()
+        skill = _make_source_skill(source_root, "doit.fancy", with_extras=True)
+
+        project = tmp_path / "project"
+        writer = SkillWriter(project_root=project)
+        result = writer.write_skill(skill)
+
+        target_dir = project / ".claude" / "skills" / "doit.fancy"
+        assert target_dir.is_dir()
+        assert (target_dir / "SKILL.md").is_file()
+        assert (target_dir / "reference.md").is_file()
+        assert (target_dir / "examples" / "sample.md").is_file()
+        assert result.was_overwrite is False
+        assert len(result.files_written) == 3
+
+    def test_overwrite_true_replaces_existing(self, tmp_path: Path) -> None:
+        source_root = tmp_path / "src"
+        source_root.mkdir()
+        skill = _make_source_skill(source_root, "doit.rewrite")
+
+        project = tmp_path / "project"
+        target_dir = project / ".claude" / "skills" / "doit.rewrite"
+        target_dir.mkdir(parents=True)
+        (target_dir / "stale.md").write_text("stale\n")
+
+        writer = SkillWriter(project_root=project)
+        result = writer.write_skill(skill, overwrite=True)
+
+        assert result.was_overwrite is True
+        assert not (target_dir / "stale.md").exists()
+        assert (target_dir / "SKILL.md").is_file()
+
+    def test_overwrite_false_raises_on_existing(self, tmp_path: Path) -> None:
+        source_root = tmp_path / "src"
+        source_root.mkdir()
+        skill = _make_source_skill(source_root, "doit.safe")
+
+        project = tmp_path / "project"
+        target_dir = project / ".claude" / "skills" / "doit.safe"
+        target_dir.mkdir(parents=True)
+
+        writer = SkillWriter(project_root=project)
+        with pytest.raises(FileExistsError):
+            writer.write_skill(skill, overwrite=False)
+
+    def test_write_all_iterates(self, tmp_path: Path) -> None:
+        source_root = tmp_path / "src"
+        source_root.mkdir()
+        skills = [
+            _make_source_skill(source_root, "doit.one"),
+            _make_source_skill(source_root, "doit.two"),
+        ]
+
+        project = tmp_path / "project"
+        writer = SkillWriter(project_root=project)
+        results = writer.write_all(skills)
+
+        assert [r.skill_name for r in results] == ["doit.one", "doit.two"]
+        for r in results:
+            assert (r.target_dir / "SKILL.md").is_file()


### PR DESCRIPTION
## Summary

Adds the 8 command templates that already fit under the 500-line SKILL.md budget to \`src/doit_cli/templates/skills/\`. **Stacked on Phase 5a (#793)** — base auto-retargets to \`develop\` once that merges.

| Skill | Lines |
|:------|------:|
| doit.roadmapit | 473 |
| doit.checkin | 453 |
| doit.reviewit | 413 |
| doit.fixit | 356 |
| doit.taskit | 352 |
| doit.testit | 346 |
| doit.implementit | 335 |
| doit.planit | 321 |

## Frontmatter transform

Applied consistently to each migrated template:

- **Keep** \`description\`.
- **Add** \`name: doit.<x>\` (required), \`when_to_use:\` (trigger keywords), \`argument-hint: "[...]"\`.
- **Convert** \`allowed-tools:\` comma-separated → space-separated (Claude Code native syntax).
- **Drop** \`effort: high\` (session inheritance is spec-compliant default).
- **Drop** the \`handoffs:\` block (not a native Claude Code field; these bodies already have inline "Next Steps" sections so no behavior change).

Body content preserved verbatim.

## New contract test (55 checks)

\`tests/contract/test_bundled_skills.py\` parameterizes every shipped skill and asserts the April 2026 contract:

- Required fields present (name, description)
- Recommended fields present (when_to_use, allowed-tools)
- No Claude leaks (handoffs, effort)
- Under the 500-line SKILL.md budget
- Under the 1,536-char description+when_to_use budget
- \`SkillTemplate.validate()\` returns an empty list

Plus \`test_every_command_has_a_skill_counterpart\` — a migration-status gate that asserts the only un-migrated templates are the four expected for **Phase 5c** (specit, researchit, documentit, scaffoldit). Fails loud when someone adds a new command template without a skill counterpart, or when 5c completes and this expected-set shrinks.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,814** tests pass (1,759 prior + 55 new)
- [x] Every SKILL.md round-trips through \`yaml.safe_load\`
- [x] Every shipped skill passes \`SkillTemplate.validate()\`
- [ ] CI green on Ubuntu / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)