### PR TITLE
feat(skills): migrate 4 oversized templates with file splitting (Phase 5c)

### DIFF
--- a/src/doit_cli/templates/skills/doit.documentit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.documentit/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: doit.documentit
+description: Organize, index, audit, and enhance project documentation aligned with scaffoldit conventions.
+when_to_use: Use when the user wants to organize project docs, generate the documentation index, audit coverage, cleanup duplicates,
+  or enhance command templates.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[organize | index | audit | cleanup | enhance]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+You are managing project documentation. This command supports multiple operations:
+
+- `organize` - Reorganize documentation into standard structure
+- `index` - Generate or update docs/index.md
+- `audit` - Check documentation health (links, headers, coverage)
+- `cleanup` - Identify duplicates and orphaned files
+- `enhance-templates` - Suggest improvements to command templates
+
+If no subcommand is provided, show an interactive menu.
+
+## Subcommand Detection
+
+Parse $ARGUMENTS to detect the operation:
+
+1. **If empty**: Show interactive menu (step 1)
+2. **If starts with "organize"**: Execute organize workflow (step 2)
+3. **If starts with "index"**: Execute index workflow (step 3)
+4. **If starts with "audit"**: Execute audit workflow (step 4)
+5. **If starts with "cleanup"**: Execute cleanup workflow (step 5)
+6. **If starts with "enhance-templates"**: Execute enhance workflow (step 6)
+
+---
+
+## Step 1: Interactive Menu (Default)
+
+If no subcommand provided, present this menu:
+
+```text
+Documentation Management
+
+Choose an operation:
+
+1. organize         - Reorganize documentation into standard structure
+2. index            - Generate or update docs/index.md
+3. audit            - Check documentation health
+4. cleanup          - Find duplicates and orphaned files
+5. enhance-templates - Suggest template improvements
+
+Enter choice (1-5) or operation name:
+```
+
+Wait for user selection, then execute the corresponding workflow.
+
+---
+
+## Step 2: Organize Documentation (FR-005 to FR-009)
+
+### 2.1 Scan for Documentation Files
+
+Search for markdown files in non-standard locations:
+
+```text
+Scanning locations:
+- Root directory (*.md except README.md, CHANGELOG.md, LICENSE.md)
+- Any folder not in docs/, specs/, .doit/, .claude/, node_modules/
+- Look for: *.md, *.mdx files
+```
+
+### 2.2 Categorize Files
+
+Assign each file to a category based on content analysis:
+
+| Pattern | Category | Target Directory |
+| ------- | -------- | ---------------- |
+| Contains "# Feature:" or feature-like content | Features | docs/features/ |
+| Contains "## Steps", "How to", tutorial content | Guides | docs/guides/ |
+| Contains API endpoints, method signatures | API | docs/api/ |
+| Contains template placeholders, scaffolding | Templates | docs/templates/ |
+| Binary files (images, PDFs) | Assets | docs/assets/ |
+| Other markdown | Other | docs/ |
+
+### 2.3 Generate Migration Report
+
+Create a report showing proposed changes:
+
+```markdown
+# Documentation Migration Plan
+
+**Generated**: [DATE]
+
+## Proposed Changes
+
+| Current Location | New Location | Reason |
+| ---------------- | ------------ | ------ |
+| path/to/file.md | docs/guides/file.md | Tutorial content detected |
+
+## Directories to Create
+
+- docs/features/
+- docs/guides/
+- docs/api/
+- docs/templates/
+- docs/assets/
+
+## Confirmation Required
+
+Proceed with migration? (y/n)
+```
+
+### 2.4 Execute Migration
+
+**IMPORTANT**: Only proceed after user confirmation.
+
+For each file to move:
+1. Check if git is available: `git rev-parse --git-dir 2>/dev/null`
+2. If git available: Use `git mv [source] [destination]` to preserve history
+3. If git not available: Use standard file move
+4. Create target directories if they don't exist
+5. Report each move as it completes
+
+### 2.5 Report Results
+
+```text
+Migration Complete:
+- Files moved: X
+- Directories created: Y
+- Files unchanged: Z
+
+Next steps:
+- Run `/doit.documentit index` to update documentation index
+```
+
+---
+
+## Step 3: Generate Documentation Index (FR-010 to FR-014)
+
+### 3.1 Read Template
+
+Load `.doit/templates/docs-index-template.md` for structure reference.
+
+### 3.2 Scan Documentation
+
+Scan `docs/` directory and subdirectories:
+
+```text
+For each .md file found:
+1. Extract title from first # heading (or use filename)
+2. Extract description from first non-heading paragraph (max 80 chars)
+3. Get file modification date
+4. Assign to category based on directory:
+   - docs/features/ → Features
+   - docs/guides/ → Guides
+   - docs/api/ → API Reference
+   - docs/templates/ → Templates
+   - docs/ (root) → Other
+```
+
+### 3.3 Generate Index Content
+
+Create categorized tables:
+
+```markdown
+<!-- BEGIN:AUTO-GENERATED section="documentation-index" -->
+
+## Features
+
+| Document | Description | Last Modified |
+| -------- | ----------- | ------------- |
+| [Feature Name](./features/feature.md) | First paragraph summary... | 2026-01-10 |
+
+## Guides
+
+| Document | Description | Last Modified |
+| -------- | ----------- | ------------- |
+| [Guide Name](./guides/guide.md) | First paragraph summary... | 2026-01-10 |
+
+[... other categories ...]
+
+<!-- END:AUTO-GENERATED -->
+```
+
+### 3.4 Update or Create Index
+
+1. If `docs/index.md` exists:
+   - Read existing file
+   - Find content between `<!-- BEGIN:AUTO-GENERATED -->` and `<!-- END:AUTO-GENERATED -->`
+   - Replace only that section, preserving all other content
+2. If `docs/index.md` doesn't exist:
+   - Create new file using template structure
+   - Fill in auto-generated sections
+
+### 3.5 Report Results
+
+```text
+Index Updated:
+- Total files indexed: X
+- Categories: Features (X), Guides (X), API (X), Templates (X), Other (X)
+- Location: docs/index.md
+```
+
+---
+
+## Step 4: Audit Documentation Health (FR-020 to FR-024)
+
+### 4.1 Check for Broken Links
+
+Parse all markdown files in docs/ for internal links:
+
+```text
+Link patterns to check:
+- [text](relative/path.md)
+- [text](./relative/path.md)
+- [text](/absolute/path.md)
+- ![alt](path/to/image.png)
+```
+
+For each link, verify the target file exists.
+
+### 4.2 Check for Missing Headers
+
+For each markdown file:
+- Check if file starts with `# ` heading
+- Flag files without proper title headers
+
+### 4.3 Check Documentation Coverage
+
+Cross-reference completed features with documentation:
+
+```text
+1. Scan specs/ for completed features (check for tasks.md with all [x])
+2. For each completed feature, check if docs/features/[feature-name].md exists
+3. Report features missing user documentation
+```
+
+### 4.4 Generate Audit Report (FR-023, FR-024)
+
+```markdown
+# Documentation Audit Report
+
+**Generated**: [DATE]
+
+## Summary
+
+| Metric | Count |
+| ------ | ----- |
+| Total Documentation Files | X |
+| Files with Issues | X |
+| Broken Links | X |
+| Missing Headers | X |
+| Coverage Score | X% |
+
+## Issues by Severity
+
+### Errors (Must Fix)
+
+| File | Issue | Suggestion |
+| ---- | ----- | ---------- |
+| docs/guide.md | Broken link to ./missing.md | Update or remove link |
+
+### Warnings (Should Fix)
+
+| File | Issue | Suggestion |
+| ---- | ----- | ---------- |
+| docs/api/endpoint.md | Missing # header | Add title heading |
+
+### Info (Consider)
+
+| File | Issue | Suggestion |
+| ---- | ----- | ---------- |
+| docs/old-doc.md | No internal links | Consider linking to related docs |
+
+## Coverage Analysis
+
+| Feature | Spec Status | User Docs | Status |
+| ------- | ----------- | --------- | ------ |
+| 008-roadmapit | Complete | Exists | ✅ |
+| 007-cli-rename | Complete | Missing | ⚠️ |
+```
+
+---
+
+## Step 5: Cleanup Redundant Documentation (FR-025 to FR-028)
+
+### 5.1 Find Potential Duplicates
+
+Compare files for similarity:
+
+```text
+Duplicate detection methods:
+1. Exact title match (# heading)
+2. Near-identical titles (fuzzy match)
+3. First 500 characters identical
+4. Same filename in different directories
+```
+
+### 5.2 Find Orphaned Files
+
+Track all internal links across documentation:
+
+```text
+1. Build link graph: file → [files it links to]
+2. Find files not linked from any other file
+3. Exclude index.md and README.md from orphan check
+4. Flag truly orphaned files
+```
+
+### 5.3 Generate Cleanup Suggestions (FR-027, FR-028)
+
+```markdown
+# Documentation Cleanup Suggestions
+
+## Potential Duplicates
+
+| File 1 | File 2 | Similarity | Suggestion |
+| ------ | ------ | ---------- | ---------- |
+| docs/setup.md | docs/guides/setup.md | 95% | Consolidate into guides/ |
+
+## Orphaned Files
+
+| File | Last Modified | Action |
+| ---- | ------------- | ------ |
+| docs/old-notes.md | 2025-06-01 | Review for deletion |
+
+## Actions
+
+For each suggestion, choose:
+- [A]ccept - Apply the suggestion
+- [R]eject - Keep files as-is
+- [S]kip - Decide later
+
+Enter choices (e.g., "A1 R2 S3"):
+```
+
+### 5.4 Apply Accepted Changes
+
+Only make changes for accepted suggestions:
+- For duplicates: Merge content, remove duplicate
+- For orphans: Delete or move to archive based on user choice
+
+---
+
+## Additional Reference
+
+For the full set of sections that follow this playbook, see [reference.md](reference.md). Claude loads it on demand when the content is needed.

--- a/src/doit_cli/templates/skills/doit.documentit/reference.md
+++ b/src/doit_cli/templates/skills/doit.documentit/reference.md
@@ -1,0 +1,173 @@
+# doit.documentit — detailed reference
+
+This file continues the playbook in [SKILL.md](SKILL.md) for sections that don't need to sit in the main context at all times.
+
+## Step 6: Enhance Command Templates (FR-029 to FR-032)
+
+### 6.1 Scan Command Templates
+
+Read all files in `.claude/commands/`:
+
+```text
+For each command file, check:
+1. YAML frontmatter present and valid
+2. Description field exists
+3. ## Examples section exists
+4. ## User Input section exists
+5. ## Outline section exists
+6. Consistent heading structure
+```
+
+### 6.2 Identify Missing Elements (FR-029, FR-030)
+
+```markdown
+# Template Enhancement Report
+
+## Files Analyzed
+
+| File | Frontmatter | Examples | User Input | Outline | Score |
+| ---- | ----------- | -------- | ---------- | ------- | ----- |
+| doit.specit.md | ✅ | ✅ | ✅ | ✅ | 100% |
+| doit.planit.md | ✅ | ❌ | ✅ | ✅ | 75% |
+```
+
+### 6.3 Generate Improvement Suggestions
+
+For each file with missing elements:
+
+```markdown
+## Suggested Improvements
+
+### doit.planit.md
+
+**Missing: ## Examples section**
+
+Suggested addition:
+
+## Examples
+
+```text
+# Create implementation plan with tech stack
+/doit.planit Use React with TypeScript for frontend, FastAPI for backend
+
+# Plan with specific architecture
+/doit.planit Microservices architecture with message queue
+```
+
+**Accept this suggestion? (y/n)**
+```
+
+### 6.4 Apply Enhancements
+
+For accepted suggestions:
+1. Read current file content
+2. Insert suggested section at appropriate location
+3. Preserve all existing content and functionality
+4. Write updated file
+
+---
+
+## Validation Rules
+
+Before any file modification:
+1. **Always confirm** with user before moving, deleting, or modifying files
+2. **Backup first** when modifying existing files
+3. **Preserve markers** - never modify content outside auto-generated markers
+4. **Check git status** before bulk operations
+
+## Notes
+
+- This command never modifies files in specs/ or .doit/templates/
+- Binary files (images, PDFs) are cataloged but content is not analyzed
+- Symlinks are followed for reading but flagged in audit
+- Large files (>1MB markdown) are skipped with warning
+
+---
+
+## Error Recovery
+
+### Missing Documentation Sources
+
+The documentation generator could not find expected source files.
+
+**ERROR** | If source files referenced by the documentation are not found:
+
+1. Check that all source directories exist: `ls src/ docs/ specs/`
+2. Verify the project structure matches what documentit expects
+3. If files were recently moved or renamed, update the documentation configuration
+4. Re-run `/doit.documentit` after fixing the source paths
+5. Verify: `ls src/ docs/ specs/` confirms all expected source directories exist
+
+> Prevention: Run `doit verify` before documentation generation to confirm project structure
+
+If the above steps don't resolve the issue: manually specify source directories when running the documentation command.
+
+### Index Generation Failure
+
+The documentation index could not be generated from the available content.
+
+**ERROR** | If the documentation index fails to generate:
+
+1. Check if the documentation directory exists and has content: `ls docs/`
+2. Verify no files have syntax errors that prevent parsing
+3. Try generating documentation for a single file to isolate the issue
+4. Re-run `/doit.documentit` after fixing any issues
+5. Verify: `ls docs/index.md` confirms the index file was generated
+
+> Prevention: Ensure all documentation files have valid markdown syntax before generating the index
+
+If the above steps don't resolve the issue: manually create the index file based on the available documentation structure.
+
+### Stale Cross-References
+
+The documentation contains links to files or sections that no longer exist.
+
+**WARNING** | If stale cross-references are detected:
+
+1. Review the list of broken references in the documentation output
+2. Update or remove references to files that have been moved or deleted
+3. Check for renamed files that need their references updated
+4. Re-run `/doit.documentit` to verify all references are valid
+5. Verify: no broken reference warnings appear in the output
+
+> Prevention: Update documentation references whenever you rename or move files
+
+If the above steps don't resolve the issue: use `grep -r "](.*\.md)" docs/` to find all markdown links and manually verify each one.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (documentation organized or indexed)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+**Documentation operation complete!**
+
+**Recommended**: Continue with your development workflow:
+- Run `/doit.specit [feature]` to create a new feature specification
+- Run `/doit.implementit` to continue implementation work
+
+**Alternative**: Run `/doit.documentit` again with a different operation (organize, index, audit, cleanup, enhance-templates).
+```
+
+### On Audit Issues Found
+
+If the audit found documentation issues:
+
+```markdown
+---
+
+## Next Steps
+
+**Documentation audit found issues.**
+
+**Recommended**: Address the issues listed above, then run `/doit.documentit audit` again to verify.
+```

--- a/src/doit_cli/templates/skills/doit.researchit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.researchit/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: doit.researchit
+description: Pre-specification research workflow for Product Owners to capture business requirements through interactive Q&A,
+  generating research artifacts for handoff to technical specification.
+when_to_use: Use when a product owner or user is capturing pre-specification research via interactive Q&A to produce research
+  artifacts (problem, users, requirements, metrics).
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[research topic or feature description]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). The user input is the feature name or description they want to research.
+
+### Flag Detection
+
+Check for the following flags in `$ARGUMENTS`:
+
+- `--auto-continue`: Skip handoff prompt and automatically invoke `/doit.specit` after research completes
+- `--skip-issues`: Skip GitHub issue creation (existing behavior)
+
+**Extract the feature description** by removing any flags from the arguments. For example:
+- Input: `user-authentication --auto-continue` → Feature: `user-authentication`, Auto-continue: true
+- Input: `payment-system` → Feature: `payment-system`, Auto-continue: false
+
+Store the `auto-continue` flag value for use in Step 7 (Handoff to Specification).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when capturing requirements
+- Consider roadmap priorities when discussing scope
+- Identify connections to related features
+
+## Outline
+
+This command guides Product Owners through a structured Q&A session to capture business requirements **without** involving technology decisions. The AI asks questions, captures answers, and generates research artifacts.
+
+**Important**: This is a business-focused workflow. Do NOT ask about:
+- Programming languages, frameworks, or databases
+- API designs or system architecture
+- Technical implementation details
+
+### Step 1: Check for Existing Research (Resume Support)
+
+Before starting a new session, check if research artifacts already exist:
+
+```bash
+# Check if feature directory exists and has research files
+ls specs/*/research.md 2>/dev/null | grep -i "$FEATURE_NAME" || echo "No existing research found"
+```
+
+**If existing research.md found for this feature**:
+1. Ask the user: "I found existing research for this feature. Would you like to:
+   - **Resume**: Continue adding to the existing research
+   - **Start Fresh**: Create new research (existing files will be backed up)"
+2. If Resume: Load existing content and identify unanswered questions
+3. If Start Fresh: Back up existing files with `.bak` extension and proceed
+
+**If no existing research found**: Proceed to Step 2.
+
+### Step 2: Establish Feature Context
+
+If `$ARGUMENTS` is empty, ask:
+> "What feature or capability would you like to research? Please describe it in a sentence or two."
+
+Once you have the feature description:
+1. Generate a feature short-name (2-4 words, lowercase, hyphenated)
+2. Create the feature directory path: `specs/{NNN-short-name}/`
+3. Confirm with user: "I'll create research artifacts for **{feature-name}** in `specs/{path}/`. Does this look correct?"
+
+### Step 3: Interactive Q&A Session
+
+Guide the user through four phases of questions. Ask questions one at a time, waiting for responses before proceeding. Adapt follow-up questions based on their answers.
+
+**Guidelines for Conducting Q&A**:
+- Ask ONE question at a time and wait for response
+- If an answer is too brief (< 10 words), gently prompt for more detail
+- Acknowledge good answers before moving to the next question
+- Skip questions that have already been answered in previous responses
+- Take notes on key themes and personas that emerge
+
+---
+
+## Phase 1: Problem Understanding
+
+**Goal**: Understand the core problem and its current impact.
+
+### Question 1.1
+> "What problem are you trying to solve with this feature?"
+
+*Wait for response. If brief, follow up with:*
+> "Can you tell me more about why this is a problem? What pain does it cause?"
+
+### Question 1.2
+> "Who currently experiences this problem? What types of people or roles?"
+
+*Wait for response.*
+
+### Question 1.3
+> "What happens today without this solution? How do people work around it?"
+
+*Wait for response.*
+
+**Phase 1 Summary**: After all questions, briefly summarize:
+> "Let me make sure I understand: [Summarize problem, affected users, current state]. Is this accurate?"
+
+---
+
+## Phase 2: Users and Goals
+
+**Goal**: Identify target users and build comprehensive persona profiles using the persona template.
+
+> **Template Reference**: Use `.doit/templates/persona-template.md` for the complete persona field structure.
+
+### Question 2.1 - User Identification
+> "Who are the primary users of this feature? Can you describe them?"
+
+*Wait for response. Note any distinct user types or personas. Assign each a preliminary ID (P-001, P-002, etc.).*
+
+### Question 2.2 - User Roles and Archetypes
+> "For each user type you mentioned, what is their job role or title? Would you classify them as:
+> - **Power User** (frequent, advanced needs)
+> - **Casual User** (occasional, basic needs)
+> - **Administrator** (manages system/config)
+> - **Approver** (reviews/approves work)
+> - **Observer** (views but doesn't interact directly)"
+
+*Wait for response. Assign an archetype to each persona.*
+
+### Question 2.3 - Experience and Context
+> "For your main users:
+> - What is their typical experience level (Junior/Mid/Senior/Executive)?
+> - Do they work solo, in small teams, large teams, or enterprise settings?
+> - What domain expertise do they bring?"
+
+*Wait for response. Capture demographics for each persona.*
+
+### Question 2.4 - Goals and Success
+> "What does success look like for these users? When they use this feature, what should they be able to accomplish? Are there any secondary goals or nice-to-haves?"
+
+*Wait for response. Note primary and secondary goals per persona.*
+
+### Question 2.5 - Pain Points
+> "What are the top 3 frustrations or pain points for each user type? Please prioritize them from most critical to least critical."
+
+*Wait for response. Capture prioritized pain points.*
+
+### Question 2.6 - Behavioral Patterns
+> "How would you describe how these users typically work?
+> - Technology proficiency (Low/Medium/High)?
+> - Work style (methodical, quick iterations, collaborative)?
+> - How do they make decisions (data-driven, intuitive, consensus-seeking)?"
+
+*Wait for response. Capture behavioral patterns.*
+
+### Question 2.7 - Usage Context
+> "When and where do users encounter this problem? What is their typical workflow when they would use this feature?"
+
+*Wait for response. Capture usage context.*
+
+**Phase 2 Summary**: After all questions, confirm understanding:
+> "Let me confirm the personas I've captured:
+> - **P-001**: [Name] - [Role], [Archetype], primary goal: [goal], top pain point: [pain point]
+> - **P-002**: [Name] - [Role], [Archetype], primary goal: [goal], top pain point: [pain point]
+>
+> Is this accurate?"
+
+---
+
+## Phase 2.5: Persona Relationships (if multiple personas)
+
+**Goal**: Capture how personas relate to each other for workflow understanding.
+
+> **Skip this phase** if only one persona was identified.
+
+### Question 2.5.1 - Working Relationships
+> "How do these personas work together? For example:
+> - Does one manage or supervise another?
+> - Do they collaborate as peers?
+> - Does one need to approve the other's work?
+> - Does one's work block another from proceeding?"
+
+*Wait for response. Map relationships to types: manages, reports_to, collaborates, approves, blocks.*
+
+### Question 2.5.2 - Relationship Context
+> "Can you describe the context of these relationships? For example, how often do they interact, and in what situations?"
+
+*Wait for response. Capture context for each relationship.*
+
+### Question 2.5.3 - Conflicts and Tensions
+> "Are there any situations where these personas might have conflicting goals or competing priorities? What tradeoffs might need to be made?"
+
+*Wait for response. Document conflicts for the Conflicts & Tensions section.*
+
+**Phase 2.5 Summary**: Confirm relationships:
+> "I've captured these relationships:
+> - P-001 [relationship] P-002: [context]
+> - [Any conflicts noted]
+>
+> Is this accurate?"
+
+**Bidirectional Documentation**: When documenting relationships:
+- If A manages B, add to both profiles (A: "manages P-002", B: "reports_to P-001")
+- If no relationships exist for a persona, document as "No direct relationships identified"
+
+---
+
+## Phase 3: Requirements and Constraints
+
+**Goal**: Define must-haves, nice-to-haves, and boundaries.
+
+### Question 3.1
+> "What must this feature absolutely do? What are the non-negotiable requirements?"
+
+*Wait for response. These become must-haves.*
+
+### Question 3.2
+> "What would be nice to have but isn't essential for the first version?"
+
+*Wait for response. These become nice-to-haves or future enhancements.*
+
+### Question 3.3
+> "What should this feature explicitly NOT do? Are there boundaries we should set?"
+
+*Wait for response. These become out-of-scope items.*
+
+### Question 3.4
+> "Are there any constraints we should know about? Things like timeline, budget, compliance requirements, or dependencies on other work?"
+
+*Wait for response.*
+
+**Phase 3 Summary**: Confirm scope:
+> "To summarize the scope: Must-haves are [list], nice-to-haves are [list], and out-of-scope is [list]. Any corrections?"
+
+---
+
+## Phase 4: Success Metrics
+
+**Goal**: Define how success will be measured.
+
+### Question 4.1
+> "How will you measure if this feature is successful? What metrics or outcomes would indicate it's working?"
+
+*Wait for response.*
+
+### Question 4.2
+> "What would failure look like? What outcomes would tell you this feature isn't meeting its goals?"
+
+*Wait for response.*
+
+**Phase 4 Summary**: Confirm metrics:
+> "Success will be measured by [metrics], and we'll know there's a problem if [failure indicators]. Does that sound right?"
+
+---
+
+## Step 4: Generate Research Artifacts
+
+After completing all Q&A phases, generate the research artifacts.
+
+### 4.1 Determine Feature Directory
+
+If not already established, determine the feature number by finding the **highest** existing number (to handle gaps):
+
+```bash
+# Find the highest feature number across all existing directories
+# This handles gaps (e.g., if 001, 002, 005 exist, next is 006)
+ls -d specs/[0-9][0-9][0-9]-* 2>/dev/null | sed 's/.*specs\/\([0-9]*\)-.*/\1/' | sort -n | tail -1 | awk '{printf "%03d", $1+1}'
+```
+
+If no existing directories found, start with `001`.
+
+Create the feature directory: `specs/{NNN-feature-short-name}/`
+
+### 4.2 Generate research.md
+
+Load the research template and populate it with Q&A answers:
+
+**File**: `specs/{feature}/research.md`
+
+Use the template at `.doit/templates/research-template.md` as a guide. Map Q&A answers to sections:
+
+| Q&A Phase | Template Section |
+|-----------|------------------|
+| Phase 1 (Problem) | Problem Statement, Current State |
+| Phase 2 (Users) | Target Users, Personas, User Goals |
+| Phase 3 (Requirements) | Must-Haves, Nice-to-Haves, Out of Scope, Constraints |
+| Phase 4 (Metrics) | Success Metrics, Failure Indicators |
+
+### 4.3 Generate personas.md
+
+Create comprehensive persona profiles from Phase 2 Q&A:
+
+**File**: `specs/{feature}/personas.md`
+
+Use the template at `.doit/templates/personas-output-template.md`. For each persona identified:
+
+1. **Assign unique ID**: P-001, P-002, etc.
+2. **Populate all profile fields** from Q&A answers:
+   - Identity (name, role, archetype from Q2.1, Q2.2)
+   - Demographics (experience, team size, domain from Q2.3)
+   - Goals (primary, secondary from Q2.4)
+   - Pain Points (prioritized list from Q2.5)
+   - Behavioral Patterns (tech proficiency, work style, decision making from Q2.6)
+   - Success Criteria (what success means for this persona)
+   - Usage Context (from Q2.7)
+   - Relationships (from Phase 2.5 relationship questions, if asked)
+   - Conflicts & Tensions (competing goals with other personas)
+
+3. **Create Persona Summary table** at the top with quick reference
+
+4. **Generate Relationship Map** (mermaid diagram) showing persona connections
+
+5. **Document Conflicts & Tensions** summary if any competing goals exist
+
+**Validation**: Ensure each persona has:
+- Unique ID in format P-NNN
+- All required fields populated
+- Archetype from valid enum (Power User, Casual User, Administrator, Approver, Observer)
+
+### 4.4 Generate user-stories.md
+
+Derive user stories from the Q&A responses:
+
+**File**: `specs/{feature}/user-stories.md`
+
+Use the template at `.doit/templates/user-stories-template.md`. For each identified persona and goal:
+
+1. Create a user story in Given/When/Then format:
+   - **Given** [user context/state]
+   - **When** [user action]
+   - **Then** [expected outcome]
+
+2. Assign priorities based on must-have vs. nice-to-have:
+   - Must-have requirements = P1 priority
+   - Nice-to-have requirements = P2/P3 priority
+
+3. Link each story to the persona it serves
+
+### 4.4 Generate interview-notes.md
+
+Create a template for stakeholder interviews:
+
+**File**: `specs/{feature}/interview-notes.md`
+
+Use the template at `.doit/templates/interview-notes-template.md`. Populate with:
+
+- Suggested interview questions for each identified persona
+- Space for capturing additional insights
+- Key topics to probe based on requirements
+
+### 4.5 Generate competitive-analysis.md
+
+Create a framework for competitive analysis:
+
+**File**: `specs/{feature}/competitive-analysis.md`
+
+Use the template at `.doit/templates/competitive-analysis-template.md`. Set up:
+
+- Competitor identification section
+- Feature comparison matrix based on must-have requirements
+- Differentiation opportunities based on user goals
+
+---
+
+## Step 5: Validate Research Artifacts
+
+Before presenting the summary, validate that all required artifacts were created successfully:
+
+```bash
+# Check required artifacts exist
+ls specs/{feature}/research.md 2>/dev/null || echo "WARNING: research.md not found"
+ls specs/{feature}/user-stories.md 2>/dev/null || echo "WARNING: user-stories.md not found"
+```
+
+**Build Artifact Status Table**:
+
+| Artifact | Status | Required |
+|----------|--------|----------|
+| research.md | ✓ or ✗ | Yes |
+| user-stories.md | ✓ or ✗ | Yes |
+| personas.md | ✓ or ✗ | No |
+| interview-notes.md | ✓ or ✗ | No |
+| competitive-analysis.md | ✓ or ✗ | No |
+
+**Validation Rules**:
+- If `research.md` is missing: **ERROR** - Cannot proceed to specification without research
+- If `user-stories.md` is missing: **WARNING** - Specification may be incomplete
+- Optional artifacts: Note their presence for handoff summary
+
+Store the artifact status for display in the handoff prompt.
+
+---
+
+## Additional Reference
+
+For the full set of sections that follow this playbook, see [reference.md](reference.md). Claude loads it on demand when the content is needed.

--- a/src/doit_cli/templates/skills/doit.researchit/reference.md
+++ b/src/doit_cli/templates/skills/doit.researchit/reference.md
@@ -1,0 +1,252 @@
+# doit.researchit — detailed reference
+
+This file continues the playbook in [SKILL.md](SKILL.md) for sections that don't need to sit in the main context at all times.
+
+## Step 6: Present Summary and Artifact Status
+
+After generating all artifacts, present a summary with the artifact status from Step 5:
+
+```markdown
+---
+
+## Research Session Complete
+
+### Artifact Status
+
+| Artifact | Status | Description |
+|----------|--------|-------------|
+| `specs/{feature}/research.md` | ✓ Created | Problem statement, users, goals, requirements |
+| `specs/{feature}/user-stories.md` | ✓ Created | User stories in Given/When/Then format |
+| `specs/{feature}/personas.md` | [✓ or ✗] | Comprehensive persona profiles with relationships |
+| `specs/{feature}/interview-notes.md` | [✓ or ✗] | Stakeholder interview templates |
+| `specs/{feature}/competitive-analysis.md` | [✓ or ✗] | Competitor analysis framework |
+
+### Key Findings Summary
+
+**Problem**: [One sentence summary]
+**Target Users**: [Persona list]
+**Core Requirements**: [Top 3 must-haves]
+**Success Metric**: [Primary success measure]
+```
+
+---
+
+## Step 7: Handoff to Specification
+
+### 7.1 Workflow Progress Indicator
+
+Display the current workflow position:
+
+```markdown
+┌─────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                              │
+│  ● researchit → ○ specit → ○ planit → ○ taskit → ○ implementit │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Auto-Continue Check
+
+**If `--auto-continue` flag was detected in Step 1**:
+- Skip the handoff prompt
+- Display: "Auto-continuing to specification phase..."
+- Proceed directly to invoke `/doit.specit {feature-name}`
+- **Go to Step 7.5**
+
+**If no `--auto-continue` flag**: Continue to Step 7.3
+
+### 7.3 Handoff Prompt
+
+Present the interactive handoff prompt:
+
+```markdown
+---
+
+## Continue to Specification?
+
+Your research artifacts are ready to be used for technical specification.
+
+**Options**:
+1. **Continue** - Run `/doit.specit` now with research context pre-loaded
+2. **Later** - Exit and resume specification later
+
+The specification phase will:
+- Use your research.md as context for requirements
+- Reference your user stories for acceptance scenarios
+- Create a formal specification ready for development planning
+
+Your choice: _
+```
+
+Wait for user response.
+
+### 7.4 Handle User Choice
+
+**If user selects "Continue" (or "1" or "yes")**:
+- Confirm: "Continuing to specification phase..."
+- Proceed to Step 7.5 to invoke specit
+
+**If user selects "Later" (or "2" or "no")**:
+- Display resume instructions:
+
+```markdown
+---
+
+## Session Saved
+
+Your research artifacts are saved in `specs/{feature}/`.
+
+To resume the specification phase later, run:
+```
+/doit.specit {feature-name}
+```
+
+The specification phase will automatically load your research context.
+
+┌─────────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                              │
+│  ✓ researchit → ○ specit → ○ planit → ○ taskit → ○ implementit │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+- End the session
+
+### 7.5 Invoke Specification Phase
+
+When continuing to specification (either via auto-continue or user choice):
+
+1. **Invoke** `/doit.specit {feature-name}` where `{feature-name}` is the feature directory name (e.g., `054-research-spec-pipeline`)
+2. **Pass context**: The feature directory path so specit knows where to find research artifacts
+3. **Report**: "Starting specification phase with research context from `specs/{feature}/`..."
+
+The specit command will automatically detect and load the research artifacts.
+
+---
+
+## Error Recovery
+
+### Session Interrupted
+
+The research Q&A session was interrupted before all questions were answered.
+
+**WARNING** | Your answers ARE preserved in the draft file. If the session is interrupted:
+
+1. Check for a saved draft: `ls specs/{feature}/.research-draft.md`
+2. If found, re-run `/doit.researchit {feature}` — it will offer to resume from where you left off
+3. Choose "Resume" to continue from the last unanswered question
+4. Verify: the session continues from the correct question
+
+> Prevention: Save your work frequently by answering one question at a time
+
+If the above steps don't resolve the issue: start a fresh session — your previous answers will be offered as a starting point.
+
+### Draft File Corruption
+
+The saved research draft has become unreadable or contains invalid data.
+
+**ERROR** | Your draft answers may be partially lost. If the draft file is corrupted:
+
+1. Check the draft file: `cat specs/{feature}/.research-draft.md`
+2. If unreadable, back it up: `cp specs/{feature}/.research-draft.md specs/{feature}/.research-draft.md.bak`
+3. Delete the corrupted draft: `rm specs/{feature}/.research-draft.md`
+4. Re-run `/doit.researchit {feature}` to start a fresh session
+5. Verify: the new session starts cleanly without errors
+
+If the above steps don't resolve the issue: manually create research.md by answering the research template questions directly.
+
+### Feature Directory Creation Failure
+
+The directory for research artifacts could not be created.
+
+**ERROR** | If the feature directory cannot be created:
+
+1. Check directory permissions: `ls -la specs/`
+2. Create the directory manually: `mkdir -p specs/{NNN-feature-name}/`
+3. Verify write access: `touch specs/{NNN-feature-name}/test && rm specs/{NNN-feature-name}/test`
+4. Re-run `/doit.researchit {feature}`
+5. Verify: `ls specs/{NNN-feature-name}/` shows the directory exists
+
+If the above steps don't resolve the issue: check filesystem permissions or disk space with `df -h .`
+
+### Resume vs Fresh Start Conflict
+
+Existing research artifacts were found but you're unsure whether to continue or start over.
+
+**WARNING** | If existing research is found and you're unsure how to proceed:
+
+1. Review the existing research: `cat specs/{feature}/research.md | head -20`
+2. If the existing research is still relevant, choose "Resume" to add to it
+3. If the research is outdated, choose "Start Fresh" — the old files will be backed up with `.bak` extension
+4. Verify: after your choice, the session proceeds without errors
+
+If the above steps don't resolve the issue: manually back up existing files and delete them, then start fresh.
+
+---
+
+## Edge Case Handling
+
+### Minimal or Empty Answers
+
+If the user provides very brief answers (< 10 words):
+
+> "Could you tell me a bit more? For example, [suggest specific aspects to consider]."
+
+If still minimal after follow-up, document as "[Brief: user's answer]" and note that more detail may be needed.
+
+### Conflicting Requirements
+
+If requirements appear to conflict:
+
+> "I noticed that [requirement A] might conflict with [requirement B]. How would you prioritize these, or is there a way to reconcile them?"
+
+Document the resolution or flag as "[Needs Prioritization]".
+
+### Session Interruption
+
+If the session is interrupted before completion:
+
+1. Save all captured answers to a draft file: `specs/{feature}/.research-draft.md`
+2. Include a marker indicating which questions have been answered
+3. On resume, load the draft and continue from the next unanswered question
+
+### Draft Cleanup After Completion
+
+After successfully generating all research artifacts:
+
+1. Delete the draft file: `specs/{feature}/.research-draft.md`
+2. Verify all four artifact files exist and are populated
+3. Do NOT leave draft files in the feature directory
+
+### Existing Research Files
+
+If `research.md` already exists for this feature:
+
+1. **Update mode**: Merge new answers with existing content, preserving valuable information
+2. **Version mode**: Archive existing file as `research.v1.md` and create fresh `research.md`
+
+Ask user which approach they prefer before proceeding.
+
+---
+
+## Q&A Reference Summary
+
+| Phase | Question | Purpose |
+|-------|----------|---------|
+| 1.1 | What problem are you solving? | Core problem statement |
+| 1.2 | Who experiences this problem? | Affected users |
+| 1.3 | What happens today without this? | Current state/workarounds |
+| 2.1 | Who are the primary users? | Target personas (assign P-IDs) |
+| 2.2 | What are their roles/archetypes? | Persona classification |
+| 2.3 | Experience and context? | Demographics |
+| 2.4 | What does success look like? | Goals (primary, secondary) |
+| 2.5 | Top 3 pain points? | Prioritized frustrations |
+| 2.6 | How do they work? | Behavioral patterns |
+| 2.7 | When/where do they use this? | Usage context |
+| 2.5.1 | How do personas work together? | Relationships |
+| 2.5.2 | Relationship context? | Interaction details |
+| 2.5.3 | Any conflicting goals? | Conflicts & Tensions |
+| 3.1 | What must it absolutely do? | Must-have requirements |
+| 3.2 | What's nice to have? | Future enhancements |
+| 3.3 | What should it NOT do? | Out of scope |
+| 3.4 | Any constraints? | Timeline, budget, compliance |
+| 4.1 | How will you measure success? | Success metrics |
+| 4.2 | What would failure look like? | Failure indicators |

--- a/src/doit_cli/templates/skills/doit.scaffoldit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.scaffoldit/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: doit.scaffoldit
+description: Generate project folder structure and starter files based on tech stack from constitution or user input.
+when_to_use: Use when the user wants to scaffold a new project directory structure based on the tech stack declared in the
+  constitution.
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[tech stack | framework override]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions (already in context)
+- Consider roadmap priorities (already in context)
+- Use tech stack information from constitution/tech-stack (already in context)
+- Identify connections to related specifications
+
+**DO NOT read these files again** (already in context above):
+
+- `.doit/memory/constitution.md` - principles and tech stack are in context
+- `.doit/memory/tech-stack.md` - tech decisions are in context
+- `.doit/memory/roadmap.md` - priorities are in context
+
+**Legitimate explicit reads** (NOT in context show):
+
+- `README.md` - for project description (if no constitution)
+- `package.json` or `pyproject.toml` - for existing project metadata
+- Existing project files for structure analysis
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Outline
+
+You are generating a project folder structure based on the tech stack defined in the constitution or provided by the user. This command creates directories, config files, and starter templates appropriate for the chosen technology.
+
+Follow this execution flow:
+
+### 1. Extract Tech Stack from Context
+
+Tech stack information is already loaded from `doit context show`. Extract from context:
+
+- **Tech Stack**: Languages, Frameworks, Libraries
+- **Infrastructure**: Hosting platform, Cloud provider, Database
+- **Deployment**: CI/CD pipeline, Strategy, Environments
+
+If constitution/tech-stack context is not available or has incomplete tech stack info, proceed to step 2.
+
+### 2. Tech Stack Clarification
+
+If tech stack is not fully defined, prompt the user:
+
+- "What is your primary programming language?" (e.g., Python, TypeScript, Go, Java, C#)
+- "What framework are you using?" (e.g., React, FastAPI, .NET, Spring Boot)
+- "Is this a frontend, backend, or full-stack project?"
+- "Do you need containerization (Docker)?"
+
+### 3. Structure Generation
+
+Based on detected/provided tech stack, generate the appropriate folder structure:
+
+#### React/TypeScript Frontend
+
+```text
+src/
+├── components/
+│   └── .gitkeep
+├── hooks/
+│   └── .gitkeep
+├── pages/
+│   └── .gitkeep
+├── services/
+│   └── .gitkeep
+├── styles/
+│   └── .gitkeep
+├── types/
+│   └── .gitkeep
+├── utils/
+│   └── .gitkeep
+└── App.tsx
+public/
+└── index.html
+tests/
+└── .gitkeep
+```
+
+#### .NET/C# Backend
+
+```text
+src/
+├── Controllers/
+│   └── .gitkeep
+├── Models/
+│   └── .gitkeep
+├── Services/
+│   └── .gitkeep
+├── Data/
+│   └── .gitkeep
+├── DTOs/
+│   └── .gitkeep
+└── Program.cs
+tests/
+├── Unit/
+│   └── .gitkeep
+└── Integration/
+    └── .gitkeep
+```
+
+#### Node.js/Express Backend
+
+```text
+src/
+├── controllers/
+│   └── .gitkeep
+├── models/
+│   └── .gitkeep
+├── services/
+│   └── .gitkeep
+├── routes/
+│   └── .gitkeep
+├── middleware/
+│   └── .gitkeep
+├── utils/
+│   └── .gitkeep
+└── app.js
+tests/
+└── .gitkeep
+```
+
+#### Python/FastAPI Backend
+
+```text
+src/
+├── api/
+│   ├── routes/
+│   │   └── .gitkeep
+│   └── deps.py
+├── models/
+│   └── .gitkeep
+├── schemas/
+│   └── .gitkeep
+├── services/
+│   └── .gitkeep
+├── core/
+│   ├── config.py
+│   └── security.py
+└── main.py
+tests/
+├── unit/
+│   └── .gitkeep
+└── integration/
+    └── .gitkeep
+```
+
+#### Go Backend
+
+```text
+cmd/
+└── main.go
+internal/
+├── handlers/
+│   └── .gitkeep
+├── models/
+│   └── .gitkeep
+├── services/
+│   └── .gitkeep
+├── repository/
+│   └── .gitkeep
+└── middleware/
+    └── .gitkeep
+pkg/
+└── .gitkeep
+tests/
+└── .gitkeep
+```
+
+#### Vue.js Frontend
+
+```text
+src/
+├── components/
+│   └── .gitkeep
+├── views/
+│   └── .gitkeep
+├── composables/
+│   └── .gitkeep
+├── stores/
+│   └── .gitkeep
+├── services/
+│   └── .gitkeep
+├── assets/
+│   └── .gitkeep
+├── App.vue
+└── main.ts
+public/
+└── index.html
+tests/
+└── .gitkeep
+```
+
+#### Angular Frontend
+
+```text
+src/
+├── app/
+│   ├── components/
+│   │   └── .gitkeep
+│   ├── services/
+│   │   └── .gitkeep
+│   ├── models/
+│   │   └── .gitkeep
+│   ├── guards/
+│   │   └── .gitkeep
+│   └── app.module.ts
+├── assets/
+│   └── .gitkeep
+└── environments/
+    └── .gitkeep
+tests/
+└── .gitkeep
+```
+
+#### Java/Spring Boot Backend
+
+```text
+src/
+├── main/
+│   ├── java/
+│   │   └── com/
+│   │       └── [package]/
+│   │           ├── controller/
+│   │           │   └── .gitkeep
+│   │           ├── service/
+│   │           │   └── .gitkeep
+│   │           ├── repository/
+│   │           │   └── .gitkeep
+│   │           ├── model/
+│   │           │   └── .gitkeep
+│   │           └── Application.java
+│   └── resources/
+│       └── application.yml
+└── test/
+    └── java/
+        └── .gitkeep
+```
+
+### 4. Config File Generation
+
+Generate appropriate config files based on tech stack:
+
+| Tech Stack | Config Files |
+|------------|--------------|
+| React/TypeScript | `tsconfig.json`, `package.json`, `vite.config.ts` |
+| .NET | `*.csproj`, `appsettings.json`, `appsettings.Development.json` |
+| Node.js | `package.json`, `tsconfig.json` (if TS), `.eslintrc.js` |
+| Python | `pyproject.toml`, `requirements.txt`, `.python-version` |
+| Go | `go.mod`, `go.sum` |
+| Vue | `package.json`, `vite.config.ts`, `tsconfig.json` |
+| Angular | `angular.json`, `package.json`, `tsconfig.json` |
+| Java | `pom.xml` or `build.gradle`, `application.yml` |
+
+### 5. Starter Files Generation
+
+Create minimal starter files:
+
+- `README.md` with project name, description, and setup instructions
+- `.editorconfig` for consistent coding styles
+- Appropriate `.gitkeep` files in empty directories
+
+### 6. Docker Support
+
+If containerization is required (from constitution or user input):
+
+- Create `Dockerfile` appropriate for the tech stack
+- Create `docker-compose.yml` for local development
+- Create `.dockerignore`
+
+### 7. .gitignore Generation
+
+Generate comprehensive `.gitignore` based on tech stack:
+
+- Language-specific ignores (node_modules, __pycache__, bin/obj, etc.)
+- IDE ignores (.idea, .vscode settings, etc.)
+- Environment files (.env, .env.local)
+- Build artifacts (dist, build, target)
+
+### 8. Doit Commands Generation
+
+Generate the doit command suite for the new project:
+
+1. Create `.claude/commands/` directory in the target project
+2. Copy all 11 doit command templates from `.doit/templates/commands/`:
+   - `doit.checkin.md` - Feature completion and PR creation
+   - `doit.constitution.md` - Project constitution management
+   - `doit.documentit.md` - Documentation organization and indexing
+   - `doit.implementit.md` - Task implementation execution
+   - `doit.planit.md` - Implementation planning
+   - `doit.reviewit.md` - Code review workflow
+   - `doit.roadmapit.md` - Project roadmap management
+   - `doit.scaffoldit.md` - Project scaffolding
+   - `doit.specit.md` - Feature specification
+   - `doit.taskit.md` - Task generation
+   - `doit.testit.md` - Test execution
+
+This enables new projects to immediately use the full doit workflow without manual setup.
+
+### 9. Multi-Stack Support
+
+For full-stack projects (frontend + backend), create:
+
+```text
+frontend/
+└── [frontend structure]
+backend/
+└── [backend structure]
+shared/
+└── types/  # Shared type definitions
+docker-compose.yml  # Combined services
+```
+
+### 10. Existing Project Analysis (FR-064, FR-065)
+
+If the project already has files:
+
+1. Scan existing directory structure
+2. Identify current tech stack from config files
+3. Generate analysis report showing:
+   - Detected technologies
+   - Current structure vs. recommended structure
+   - Missing recommended directories
+   - Suggested improvements
+
+### 11. Tech Stack Documentation (FR-015 to FR-018)
+
+After tech stack is determined (from constitution or user input), generate `.doit/memory/tech-stack.md`:
+
+1. Read `.doit/templates/tech-stack-template.md` for structure
+2. Populate with captured tech stack information:
+   - **Languages**: Primary language and version
+   - **Frameworks**: Main framework(s) with versions
+   - **Key Libraries**: Important dependencies with rationale
+   - **Infrastructure**: Hosting, cloud provider, database choices
+   - **Architecture Decisions**: Key decisions made during scaffolding
+
+3. If `tech-stack.md` already exists:
+   - Preserve content in "Custom Notes" section
+   - Update auto-generated sections between markers
+
+4. If `constitution.md` exists with tech info:
+   - Include relevant details from constitution
+   - Cross-reference but don't duplicate
+
+Example output structure:
+
+```markdown
+# Tech Stack
+
+**Generated**: 2026-01-10
+**Last Updated**: 2026-01-10
+
+## Additional Reference
+
+For the full set of sections that follow this playbook, see [reference.md](reference.md). Claude loads it on demand when the content is needed.

--- a/src/doit_cli/templates/skills/doit.scaffoldit/reference.md
+++ b/src/doit_cli/templates/skills/doit.scaffoldit/reference.md
@@ -1,0 +1,146 @@
+# doit.scaffoldit — detailed reference
+
+This file continues the playbook in [SKILL.md](SKILL.md) for sections that don't need to sit in the main context at all times.
+
+## Languages
+
+| Language | Version | Purpose |
+| -------- | ------- | ------- |
+| TypeScript | 5.0+ | Primary |
+
+## Frameworks
+
+| Framework | Version | Purpose |
+| --------- | ------- | ------- |
+| React | 18.x | Frontend UI |
+| FastAPI | 0.100+ | Backend API |
+
+## Key Libraries
+
+| Library | Version | Purpose | Why Chosen |
+| ------- | ------- | ------- | ---------- |
+| Tailwind | 3.x | Styling | Rapid prototyping |
+
+<!-- BEGIN:AUTO-GENERATED section="scaffold-captured" -->
+Captured during scaffold on 2026-01-10
+<!-- END:AUTO-GENERATED -->
+
+## Custom Notes
+
+[User additions preserved here]
+```
+
+### 12. Output Summary
+
+After scaffolding, provide:
+
+- List of created directories and files
+- Confirmation that doit commands were generated (11 files in `.claude/commands/`)
+- Confirmation that tech-stack.md was created in `.doit/memory/`
+- Next steps for the user
+- Suggested commands to run (e.g., `npm install`, `pip install -r requirements.txt`)
+- Reminder to run `/doit.specit` to create feature specifications
+- Reminder to run `/doit.documentit` to organize documentation
+
+## Validation
+
+Before creating files:
+
+- Confirm tech stack selection with user
+- Check for existing files that would be overwritten
+- Prompt for confirmation before creating structure
+
+## Notes
+
+- Always create `.gitkeep` files in empty directories
+- Use appropriate naming conventions for the tech stack (camelCase, snake_case, PascalCase)
+- Include comments in generated config files explaining key settings
+- Respect existing project structure when adding new directories
+
+---
+
+## Error Recovery
+
+### Directory Creation Failure
+
+The project structure could not be created due to permission or filesystem issues.
+
+**ERROR** | If directory creation fails:
+
+1. Check permissions on the target directory: `ls -la .`
+2. Verify you have write access to the current directory
+3. If permissions are insufficient, adjust them or choose a different location
+4. Retry: re-run `/doit.scaffoldit`
+5. Verify: `ls -la .doit/` confirms the directory structure was created
+
+> Prevention: Ensure you have write permissions in the target directory before scaffolding
+
+If the above steps don't resolve the issue: create the `.doit/` directory structure manually using `mkdir -p .doit/{templates,config,state,memory,scripts}`.
+
+### Template Copy Failure
+
+Template files could not be copied to the project directory.
+
+**ERROR** | If template files fail to copy:
+
+1. Check if the source templates exist: `python -c "import doit_cli; print(doit_cli.__file__)"`
+2. Verify the package installation: `pip show doit-toolkit-cli`
+3. If the package is corrupted, reinstall: `pip install --force-reinstall doit-toolkit-cli`
+4. Retry: re-run `/doit.scaffoldit`
+5. Verify: `ls .doit/templates/` shows template files
+
+If the above steps don't resolve the issue: run `doit init --force` to reinitialize from scratch.
+
+### Existing Project Conflict
+
+The target directory already contains a doit project structure.
+
+**WARNING** | If the directory already has a `.doit/` folder:
+
+1. Check the existing structure: `ls -la .doit/`
+2. If you want to preserve existing configuration, choose to merge rather than overwrite
+3. If you want a fresh start, back up first: `cp -r .doit/ .doit.backup/`
+4. Then reinitialize: `doit init --force`
+5. Verify: `doit verify` confirms the project structure is valid
+
+> Prevention: Check for existing `.doit/` directory before scaffolding a new project
+
+If the above steps don't resolve the issue: manually merge the old and new configurations by comparing `.doit.backup/` with the new `.doit/`.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (project scaffolded)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+**Project structure created!**
+
+**Recommended**: Run `/doit.specit [feature description]` to create your first feature specification.
+
+**Alternative**: Run `/doit.documentit organize` to organize any existing documentation.
+```
+
+### On Existing Project (structure already exists)
+
+If the project already has a structure:
+
+```markdown
+---
+
+## Next Steps
+
+**Project structure analyzed!**
+
+**Recommended**: Run `/doit.specit [feature description]` to start developing a new feature.
+
+**Alternative**: Run `/doit.documentit audit` to check documentation health.
+```

--- a/src/doit_cli/templates/skills/doit.specit/SKILL.md
+++ b/src/doit_cli/templates/skills/doit.specit/SKILL.md
@@ -1,0 +1,473 @@
+---
+name: doit.specit
+description: Create or update the feature specification from a natural language feature description, with integrated ambiguity
+  resolution and GitHub issue creation.
+when_to_use: 'Use when the user wants to create or update a feature specification: capture requirements, user stories, acceptance
+  criteria, and optionally create matching GitHub issues.'
+allowed-tools: Read Write Edit Glob Grep Bash
+argument-hint: '[feature description]'
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Load Project Context
+
+Before proceeding, load the project context to inform your responses:
+
+```bash
+doit context show
+```
+
+**If the command fails or doit is not installed**: Continue without context, but note that alignment with project principles cannot be verified.
+
+**Use loaded context to**:
+
+- Reference constitution principles when making decisions
+- Consider roadmap priorities
+- Identify connections to related specifications
+
+**For this command specifically**:
+
+- Reference constitution principles when defining requirements
+- Align new features with roadmap priorities
+- Check for overlap with existing specifications
+- **Reference project personas** (if `.doit/memory/personas.md` is loaded in context): When generating user stories, include `Persona: P-NNN` references in each user story header matching the most relevant persona. If both project-level personas (from context) and feature-level personas (from `specs/{feature}/personas.md`) exist, feature-level personas take precedence.
+
+## Code Quality Guidelines
+
+Before generating or modifying code:
+
+1. **Search for existing implementations** - Use Glob/Grep to find similar functionality before creating new code
+2. **Follow established patterns** - Match existing code style, naming conventions, and architecture
+3. **Avoid duplication** - Reference or extend existing utilities rather than recreating them
+4. **Check imports** - Verify required dependencies already exist in the project
+
+**Context already loaded** (DO NOT read these files again):
+
+- Constitution principles and tech stack
+- Roadmap priorities
+- Current specification
+- Related specifications
+
+## Artifact Storage
+
+- **Temporary scripts**: Save to `.doit/temp/{purpose}-{timestamp}.sh` (or .py/.ps1)
+- **Status reports**: Save to `specs/{feature}/reports/{command}-report-{timestamp}.md`
+- **Create directories if needed**: Use `mkdir -p` before writing files
+- Note: `.doit/temp/` is gitignored - temporary files will not be committed
+
+## Load Research Artifacts (if available)
+
+Before generating a specification, check if research artifacts exist from a prior `/doit.researchit` session:
+
+```bash
+# Check for research artifacts in the feature directory
+# Pattern: specs/{NNN-feature-name}/research.md
+ls specs/*/research.md 2>/dev/null | head -5
+```
+
+**If research.md exists for this feature**:
+
+1. **Load research.md** - Read the problem statement, target users, goals, and requirements
+2. **Load user-stories.md** (if exists) - Read the user stories to inform acceptance scenarios
+3. **Use research as context**:
+   - Map Problem Statement section to spec Summary
+   - Map Target Users/Personas to user story actors
+   - Map Must-Have requirements to P1 functional requirements
+   - Map Nice-to-Have requirements to P2/P3 functional requirements
+   - Map Success Metrics to spec Success Criteria
+   - Map Out of Scope items directly to spec Out of Scope section
+
+4. **Reference research in spec**: Add a "Research Reference" link at the top of the generated spec:
+
+   ```markdown
+   **Research**: [research.md](research.md) | [user-stories.md](user-stories.md)
+   ```
+
+**If research artifacts also include**:
+
+- `interview-notes.md`: Review for additional user insights and quote notable findings
+- `competitive-analysis.md`: Review for differentiation opportunities and market context
+- `personas.md`: Load comprehensive persona profiles for user story generation (see below)
+
+**If NO research artifacts found**: Proceed normally with user-provided feature description.
+
+### Research Context Confirmation
+
+**When research artifacts ARE loaded**, display a confirmation message to the user:
+
+```markdown
+## Research Context Loaded
+
+Found research artifacts from prior `/doit.researchit` session:
+
+| Artifact | Status |
+|----------|--------|
+| research.md | ✓ Loaded |
+| user-stories.md | [✓ Loaded or ✗ Not found] |
+| personas.md | [✓ Loaded or ✗ Not found] |
+| interview-notes.md | [✓ Loaded or ✗ Not found] |
+| competitive-analysis.md | [✓ Loaded or ✗ Not found] |
+
+These artifacts will inform the specification. Requirements from research.md will be mapped to functional requirements.
+```
+
+This confirmation helps users understand that their research is being used and provides transparency about which artifacts were found.
+
+## Load Personas (if available)
+
+Check if comprehensive persona profiles exist from `/doit.researchit`:
+
+```bash
+# Check for personas.md in the feature directory
+ls specs/*/personas.md 2>/dev/null | head -5
+```
+
+**If personas.md exists for this feature**:
+
+1. **Load personas.md** - Read the persona summary table and detailed profiles
+2. **Extract persona data for matching**:
+   - Parse the Persona Summary table for ID (P-001, P-002) and Name columns
+   - Parse the Detailed Profiles section for each persona's Goals (primary and secondary) and Pain Points fields
+   - Store as a list: `[{id: "P-001", name: "Developer Dana", role: "Senior Developer", archetype: "Power User", primary_goal: "...", pain_points: ["...", "..."], usage_context: "..."}, ...]`
+   - These fields are the primary inputs for persona matching (see Persona Matching Rules below)
+3. **Use personas for user story generation**:
+   - Each user story MUST reference a persona ID in the header
+   - Format: `### User Story N - [Title] (Priority: PN) | Persona: P-XXX`
+   - Match user stories to the persona whose goals/pain points they address
+4. **Reference personas in spec**: Add a "Personas Reference" link at the top of the generated spec:
+
+   ```markdown
+   **Personas**: [personas.md](personas.md)
+   ```
+
+**When generating user stories with personas**:
+
+- Review each persona's primary goal and pain points
+- Create user stories that directly address those goals/pain points
+- Include the persona's name, ID, archetype, and primary goal in the story context
+- After determining the matching persona, include the persona ID in the story header using the format from spec-template.md: `### User Story N - [Title] (Priority: PN) | Persona: P-NNN`
+- In the story body, reference the persona's name, archetype, and primary goal to give developers immediate context without cross-referencing personas.md
+- Example:
+
+  ```markdown
+  ### User Story 1 - Quick Task Creation (Priority: P1) | Persona: P-001
+
+  As **Developer Dana (P-001)**, a Power User whose primary goal is rapid task entry,
+  I want to create tasks with a single command so that I can stay in flow...
+  ```
+
+**If NO personas.md found**:
+
+- Proceed normally without persona references
+- Use generic "As a user..." format for user stories
+- If the feature requires specific user types, use a default "Primary User" placeholder
+- If `personas.md` exists but contains no valid persona entries (no P-NNN IDs found), treat as no personas available
+
+**When No Personas Are Available**:
+
+- Skip all persona matching rules below
+- Generate stories using the standard header format without `| Persona: P-NNN` suffix
+- Skip the traceability table update step
+- Skip the persona coverage report
+- Do NOT raise errors or warnings about missing personas — this is a valid state
+
+## Persona Matching Rules (when personas loaded)
+
+When generating user stories with persona context available, follow these matching rules in priority order to assign the most relevant persona to each story:
+
+1. **Direct goal match**: If a story directly addresses a persona's primary goal, assign that persona. Confidence: High.
+2. **Pain point match**: If a story addresses one of the persona's top 3 pain points, assign that persona. Confidence: High.
+3. **Usage context match**: If a story fits the persona's described usage context but not a specific goal, assign that persona. Confidence: Medium.
+4. **Role/archetype match**: If a story aligns with the persona's role or archetype but not specific goals, assign that persona. Confidence: Medium.
+5. **Multi-persona**: If a story equally addresses the goals of 2 or more personas, list all relevant IDs comma-separated in the header: `| Persona: P-001, P-002`. In the story body, reference all matched personas. Limit multi-persona tagging to stories that genuinely serve multiple personas — most stories should map to a single primary persona.
+6. **No match**: If no persona clearly matches, generate the story without a Persona tag. Flag it in the coverage report as "unmapped."
+
+For each user story you generate, review the loaded personas and assign the persona whose goals/pain points are most directly addressed by the story.
+
+### Update Persona Traceability
+
+After generating all user stories with persona mappings:
+
+1. Read the feature's `specs/{feature}/personas.md` file (if it exists)
+2. Find the `## Traceability` → `### Persona Coverage` table
+3. Replace the table content with current mappings:
+   - For each persona, list all story IDs (from the spec) that reference it
+   - Include personas with zero mapped stories (empty "User Stories Addressing" column) to signal coverage gaps
+   - Set "Primary Focus" to the main theme of the mapped stories
+4. Write the updated personas.md
+
+This is a full replacement on each `/doit.specit` run — the table should always reflect the current spec state.
+
+### Persona Coverage Report
+
+After story generation and traceability update, display a Persona Coverage summary:
+
+```markdown
+## Persona Coverage
+
+| Persona | Stories | Coverage |
+| ------- | ------- | -------- |
+| P-001 (Name) | US-001, US-003 | ✓ Covered |
+| P-002 (Name) | US-002 | ✓ Covered |
+| P-003 (Name) | — | ⚠ Underserved |
+```
+
+- Mark personas with ≥1 mapped story as "✓ Covered"
+- Mark personas with 0 mapped stories as "⚠ Underserved"
+- If any personas are underserved, add: "> ⚠ {N} persona(s) have no user stories mapped. Consider adding stories that address their goals."
+- Only display this section when personas are available (skip when no personas loaded)
+
+## Outline
+
+The text the user typed after `/doit.doit` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the branch:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Check for existing branches before creating new one**:
+
+   a. First, fetch all remote branches to ensure we have the latest information:
+
+      ```bash
+      git fetch --all --prune
+      ```
+
+   b. Find the highest feature number across all sources for the short-name:
+      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
+      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
+      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+
+   c. Determine the next available number:
+      - Extract all numbers from all three sources
+      - Find the highest number N
+      - Use N+1 for the new branch number
+
+   d. Run the script `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
+      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.doit/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+
+   **IMPORTANT**:
+   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
+   - Only match branches/directories with the exact short-name pattern
+   - If no existing branches/directories found with this short-name, start with number 1
+   - You must only ever run this script once per feature
+   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
+   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+
+3. Load `.doit/templates/spec-template.md` to understand required sections.
+
+4. Follow this execution flow:
+
+    1. Parse user description from Input
+       If empty, check for recent research:
+       ```bash
+       # Find most recently modified research.md
+       ls -t specs/*/research.md 2>/dev/null | head -1
+       ```
+
+       **If recent research found**:
+       - Extract the feature name from the directory path (e.g., `specs/054-my-feature/research.md` → `054-my-feature`)
+       - Present suggestion to user:
+         ```markdown
+         No feature specified. Did you mean to continue with **{feature-name}**?
+
+         Research artifacts were recently created for this feature.
+
+         - **Yes** - Continue with {feature-name}
+         - **No** - Enter a new feature description
+         ```
+       - Wait for user response
+       - If "Yes": Use the suggested feature name and load its research artifacts
+       - If "No": Prompt user for new feature description
+
+       **If NO recent research found**:
+       ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. **Generate Mermaid Visualizations** (FR-001, FR-002, FR-003):
+
+   After writing the spec content, generate visual diagrams to enhance understanding:
+
+   a. **User Journey Visualization**:
+      - Parse all user stories from the spec (### User Story N - [Title])
+      - For each user story, extract the key action flow from acceptance scenarios
+      - Generate a flowchart with one subgraph per user story
+      - Use format: `US{N}_S[Start] --> US{N}_A[Action] --> US{N}_E[End]`
+      - Replace the placeholder in `<!-- BEGIN:AUTO-GENERATED section="user-journey" -->` markers
+
+      ```mermaid
+      flowchart LR
+          subgraph "User Story 1 - [Actual Title]"
+              US1_S[User Starts] --> US1_A[Key Action] --> US1_E[Expected Outcome]
+          end
+          subgraph "User Story 2 - [Actual Title]"
+              US2_S[User Starts] --> US2_A[Key Action] --> US2_E[Expected Outcome]
+          end
+      ```
+
+   b. **Entity Relationships** (FR-002, FR-003):
+      - Check if Key Entities section exists and has content
+      - **IF Key Entities defined**:
+        - Parse entity names and relationships from the Key Entities section
+        - Generate an ER diagram showing entities and their relationships
+        - Replace content in `<!-- BEGIN:AUTO-GENERATED section="entity-relationships" -->` markers
+      - **IF NO Key Entities defined**:
+        - **REMOVE the entire Entity Relationships section** (from `## Entity Relationships` to before `## Requirements`)
+        - Do NOT leave an empty placeholder section
+
+      ```mermaid
+      erDiagram
+          ENTITY1 ||--o{ ENTITY2 : "relationship description"
+
+          ENTITY1 {
+              string id PK
+              string key_attribute
+          }
+      ```
+
+   c. **Diagram Validation**:
+      - Verify mermaid syntax is valid (proper diagram type, matching brackets)
+      - Check node count does not exceed 20 per diagram (split into subgraphs if needed)
+      - Ensure all entity names from Key Entities are represented
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/doit.planit`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 6
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/doit.planit`).
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+
+## Additional Reference
+
+For the full set of sections that follow this playbook, see [reference.md](reference.md). Claude loads it on demand when the content is needed.

--- a/src/doit_cli/templates/skills/doit.specit/reference.md
+++ b/src/doit_cli/templates/skills/doit.specit/reference.md
@@ -1,0 +1,326 @@
+# doit.specit — detailed reference
+
+This file continues the playbook in [SKILL.md](SKILL.md) for sections that don't need to sit in the main context at all times.
+
+## General Guidelines
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: RESTful APIs unless specified otherwise
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)
+
+---
+
+## Integrated Ambiguity Scan
+
+After creating the initial spec, perform a structured ambiguity scan using this 8-category taxonomy. For each category, assess status: Clear / Partial / Missing.
+
+### Category Taxonomy
+
+1. **Functional Scope & Behavior**
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+2. **Domain & Data Model**
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+
+3. **Interaction & UX Flow**
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+4. **Non-Functional Quality Attributes**
+   - Performance (latency, throughput targets)
+   - Scalability assumptions
+   - Security & privacy requirements
+
+5. **Integration & External Dependencies**
+   - External services/APIs
+   - Data import/export formats
+
+6. **Edge Cases & Failure Handling**
+   - Negative scenarios
+   - Conflict resolution
+
+7. **Constraints & Tradeoffs**
+   - Technical constraints
+   - Explicit tradeoffs
+
+8. **Terminology & Consistency**
+   - Canonical glossary terms
+   - Avoided synonyms
+
+### Clarification Process
+
+If Partial or Missing categories exist that require user input:
+
+1. Generate up to **5 clarification questions** maximum
+2. Each question must be answerable with:
+   - Multiple-choice (2-5 options), OR
+   - Short answer (≤5 words)
+3. Present questions sequentially, one at a time
+4. After each answer, integrate into the appropriate spec section
+5. Ensure **no [NEEDS CLARIFICATION] markers remain** in final output
+
+---
+
+## GitHub Issue Integration (FR-048, FR-049)
+
+After the spec is complete and validated, create GitHub issues if a remote is available.
+
+### Issue Creation Process
+
+1. **Detect GitHub Remote**:
+
+   ```bash
+   git remote get-url origin 2>/dev/null
+   ```
+
+   If no remote or not a GitHub URL, skip issue creation gracefully.
+
+2. **Create Epic Issue**:
+   - Title: `[Epic]: {Feature Name from spec}`
+   - Labels: `epic`
+   - Body: Summary section from spec + link to spec file
+   - Store Epic issue number for linking
+
+3. **Create Feature Issues for Each User Story**:
+   - Title: `[Feature]: {User Story Title}`
+   - Labels: `feature`, `priority:{P1|P2|P3}`
+   - Body: User story content + acceptance scenarios
+   - Add `Part of Epic #XXX` reference
+
+4. **Skip Flag Option**:
+   - If `--skip-issues` provided in arguments, skip GitHub issue creation
+   - Example: `/doit.doit "my feature" --skip-issues`
+
+5. **Graceful Fallback**:
+   - If `gh` CLI not available: warn and continue without issues
+   - If GitHub API fails: log error, continue with spec creation
+   - Never fail the entire command due to GitHub issues
+
+### Issue Creation Commands
+
+```bash
+# Create Epic
+gh issue create --title "[Epic]: {FEATURE_NAME}" \
+  --label "epic" \
+  --body "$(cat <<'EOF'
+## Summary
+{SPEC_SUMMARY}
+
+## Success Criteria
+{SUCCESS_CRITERIA}
+
+---
+Spec file: `{SPEC_FILE_PATH}`
+EOF
+)"
+
+# Create Feature for each user story
+gh issue create --title "[Feature]: {USER_STORY_TITLE}" \
+  --label "feature,priority:{PRIORITY}" \
+  --body "$(cat <<'EOF'
+## Description
+{USER_STORY_CONTENT}
+
+## Acceptance Scenarios
+{ACCEPTANCE_SCENARIOS}
+
+---
+Part of Epic #{EPIC_NUMBER}
+EOF
+)"
+```
+
+### Output
+
+Report created issues at the end:
+
+```markdown
+## GitHub Issues Created
+
+- Epic: #{EPIC_NUMBER} - {EPIC_TITLE}
+- Features:
+  - #{FEATURE_1_NUMBER} - {FEATURE_1_TITLE} (P1)
+  - #{FEATURE_2_NUMBER} - {FEATURE_2_TITLE} (P2)
+```
+
+If issues were skipped or failed, note the reason.
+
+---
+
+## Error Recovery
+
+### Branch Creation Failure
+
+The feature branch could not be created from the current repository state.
+
+**ERROR** | If the branch creation script fails:
+
+1. Check if you have uncommitted changes: `git status`
+2. If there are conflicts, stash your changes: `git stash`
+3. Ensure the base branch is up to date: `git fetch origin && git pull`
+4. Retry branch creation by re-running `/doit.specit`
+5. Verify: `git branch --show-current` shows the new feature branch
+
+> Prevention: Commit or stash pending changes before starting a new specification
+
+If the above steps don't resolve the issue: manually create the branch with `git checkout -b {NNN-feature-name}` and create the spec file manually.
+
+### GitHub API Authentication Error
+
+GitHub issues could not be created because authentication failed.
+
+**ERROR** | If GitHub issue creation fails with an authentication error:
+
+1. Check your GitHub CLI authentication: `gh auth status`
+2. If not authenticated, log in: `gh auth login`
+3. Verify you have access to the repository: `gh repo view`
+4. Re-run `/doit.specit` — it will retry issue creation
+5. Verify: `gh issue list --limit 5` shows recent issues
+
+> Prevention: Run `gh auth status` before starting specification work
+
+If the above steps don't resolve the issue: add `--skip-issues` to skip GitHub issue creation and create issues manually later.
+
+### File Write Permission Denied
+
+The specification file could not be saved to the expected location.
+
+**ERROR** | If the spec file cannot be written:
+
+1. Check directory permissions: `ls -la specs/`
+2. Verify the feature directory exists: `ls -d specs/{NNN-feature-name}/`
+3. If the directory doesn't exist, create it: `mkdir -p specs/{NNN-feature-name}/`
+4. Check disk space: `df -h .`
+5. Verify: touch a test file in the directory: `touch specs/{NNN-feature-name}/test && rm specs/{NNN-feature-name}/test`
+
+If the above steps don't resolve the issue: check if the filesystem is read-only or if you need elevated permissions.
+
+### Missing Research Artifacts
+
+Research artifacts from a prior session were expected but not found.
+
+**WARNING** | If research.md or other artifacts are not found:
+
+1. Check if research was completed: `ls specs/*/research.md`
+2. If research exists in a different directory, verify the feature name matches
+3. If no research exists, proceed without it — the specification will be generated from the feature description alone
+4. Verify: the spec generation continues without errors
+
+> Prevention: Run `/doit.researchit` before `/doit.specit` for richer specifications
+
+If the above steps don't resolve the issue: provide a detailed feature description when running `/doit.specit` to compensate for missing research.
+
+### Ambiguity Resolution Timeout
+
+The interactive clarification session stalled or the user did not respond.
+
+**WARNING** | If the ambiguity resolution Q&A session times out or stalls:
+
+1. Note which question was being asked when the session stalled
+2. Re-run `/doit.specit` — it will regenerate the spec and present clarification questions again
+3. If you want to skip clarifications, the spec will use reasonable defaults (documented in the Assumptions section)
+4. Verify: the generated spec.md has no more than 3 `[NEEDS CLARIFICATION]` markers
+
+If the above steps don't resolve the issue: manually edit the spec.md to resolve any remaining `[NEEDS CLARIFICATION]` markers.
+
+---
+
+## Next Steps
+
+After completing this command, display a recommendation section based on the outcome:
+
+### On Success (spec created)
+
+Display the following at the end of your output:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ○ planit → ○ taskit → ○ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Run `/doit.planit` to create an implementation plan for this feature.
+```
+
+### On Success with Clarifications Needed
+
+If the spec contains [NEEDS CLARIFICATION] markers:
+
+```markdown
+---
+
+## Next Steps
+
+┌─────────────────────────────────────────────────────────────┐
+│  Workflow Progress                                          │
+│  ● specit → ○ planit → ○ taskit → ○ implementit → ○ checkin │
+└─────────────────────────────────────────────────────────────┘
+
+**Recommended**: Resolve N open questions in the spec before proceeding to planning.
+```

--- a/tests/contract/test_bundled_skills.py
+++ b/tests/contract/test_bundled_skills.py
@@ -85,17 +85,11 @@ def test_every_command_has_a_skill_counterpart() -> None:
     command_names = {p.stem for p in commands_dir.glob("doit.*.md")}
     skill_names = {s.name for s in SKILLS}
 
-    # Record the migration status so the test fails loud when someone
-    # adds a new command template without a skill counterpart.
+    # All command templates have a skill counterpart after Phase 5c. If
+    # someone adds a new command template, this test will fail loud.
     not_yet_migrated = command_names - skill_names
-    expected_not_yet = {
-        "doit.specit",
-        "doit.researchit",
-        "doit.documentit",
-        "doit.scaffoldit",
-    }
-    assert not_yet_migrated == expected_not_yet, (
-        f"Migration delta changed. Previously unmigrated: {expected_not_yet}. "
-        f"Now unmigrated: {not_yet_migrated}. "
-        f"Either finish the migration or update this test's expected set."
+    assert not_yet_migrated == set(), (
+        f"Command templates without a skills/ counterpart: "
+        f"{sorted(not_yet_migrated)}. Add a skill directory for each, or "
+        f"document why it intentionally has no skill form."
     )


### PR DESCRIPTION
## Summary

Completes the April 2026 Agent Skills migration. The 4 templates that exceeded the 500-line SKILL.md budget are now split into \`SKILL.md\` (<=500 lines) plus a supporting \`reference.md\` that Claude loads on demand.

**Stacked on PR #798 (Phase 5b).** Base auto-retargets up the chain (5c → 5b → 5a → develop) as each merges.

## Split strategy

For each template, identify the first H2 section after roughly line 400 and cut there. Everything past moves to \`reference.md\` with a pointer from SKILL.md (\`## Additional Reference\`). Preserves document order and keeps the main playbook self-contained for the 80% case.

| Skill | SKILL.md | reference.md | Split heading |
|:------|---------:|-------------:|:--------------|
| doit.specit | 474 | 327 | \`## General Guidelines\` |
| doit.researchit | 411 | 253 | \`## Step 6: Present Summary and Artifact Status\` |
| doit.documentit | 393 | 174 | \`## Step 6: Enhance Command Templates\` |
| doit.scaffoldit | 394 | 147 | \`## Languages\` |

Frontmatter transform identical to Phase 5b: added \`name\`/\`when_to_use\`/\`argument-hint\`, converted \`allowed-tools\` to space-separated form, dropped \`handoffs\` + \`effort\`.

## Contract test tightened

\`test_every_command_has_a_skill_counterpart\` previously tracked these 4 as the expected-unmigrated set. Now requires **zero** unmigrated templates. Any future command template added without a skill counterpart will fail this test loud.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,838** tests pass (1,814 prior + 24 new parameterized over the 4 new skills)
- [x] Every SKILL.md under 500 lines; every frontmatter under 1,536 chars
- [x] \`SkillTemplate.validate()\` returns \`[]\` for every shipped skill
- [ ] CI green on Ubuntu / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)