### PR TITLE
refactor(github): deprecate github_service shim with clear migration path

### DIFF
--- a/src/doit_cli/services/github_service.py
+++ b/src/doit_cli/services/github_service.py
@@ -1,20 +1,36 @@
-"""Service for GitHub operations via gh CLI.
+"""Service for GitHub operations via gh CLI (deprecated, legacy shim).
 
-This module provides the GitHubService class for interacting
-with GitHub issues, epics, milestones, and branches using the gh CLI tool.
+This module predates the provider abstraction at
+`doit_cli.services.providers.github.GitHubProvider`. It remains in the
+tree because the provider layer does not yet expose:
 
-Note:
-    This service is maintained for backward compatibility.
-    New code should use the provider abstraction layer instead:
+- bug-label filtered issue listing (`list_bugs`)
+- adding comments to issues (`add_comment`)
+- closing issues with an optional comment (`close_issue`)
+- epic operations (`fetch_epics`, `fetch_features_for_epic`, `create_epic`)
+- milestone operations beyond create/get (`get_all_milestones`,
+  `close_milestone`)
+- git branch operations (`check_branch_exists`, `create_branch`)
 
-    from doit_cli.services.provider_factory import ProviderFactory
-    provider = ProviderFactory.create()
+Until those methods land on GitHubProvider (tracked separately),
+`fixit_service`, `github_linker`, `milestone_service`, and `roadmapit_impl`
+continue to depend on this shim. New code should use the provider where
+possible.
+
+When you edit a caller, consider one of:
+    - Move a method it uses onto GitHubProvider, then update the caller
+      to use the provider directly.
+    - Add a deprecation-aware wrapper here and leave the caller alone
+      temporarily.
+    - Use `service.get_provider()` to escape into the provider API for
+      the subset of operations the provider already supports.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import warnings
 from typing import TYPE_CHECKING
 
 from ..models.fixit_models import GitHubIssue
@@ -25,6 +41,25 @@ from ..utils.github_auth import has_gh_cli, is_gh_authenticated
 if TYPE_CHECKING:
     from ..models.github_feature import GitHubFeature
     from .providers.github import GitHubProvider
+
+
+_DEPRECATION_MSG = (
+    "doit_cli.services.github_service is a legacy shim. New code should "
+    "use doit_cli.services.providers.github.GitHubProvider where the "
+    "required method exists. See the module docstring for the migration "
+    "plan and remaining gaps."
+)
+
+_deprecation_emitted = False
+
+
+def _emit_deprecation_once() -> None:
+    """Emit the module-level DeprecationWarning at most once per process."""
+    global _deprecation_emitted
+    if _deprecation_emitted:
+        return
+    _deprecation_emitted = True
+    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
 
 
 class GitHubServiceError(Exception):
@@ -48,16 +83,25 @@ class GitHubAPIError(GitHubServiceError):
 class GitHubService:
     """Manages GitHub operations via gh CLI.
 
-    This service handles all GitHub API interactions using the gh CLI tool,
-    including fetching/creating issues, epics, milestones, and branch operations.
+    .. deprecated::
+        Prefer `doit_cli.services.providers.github.GitHubProvider`. This
+        class remains because the provider abstraction does not yet cover
+        every operation the workflow services need (see module docstring).
     """
 
     def __init__(self, timeout: int = 30):
         """Initialize the GitHub service.
 
+        Emits a one-time DeprecationWarning the first time a
+        ``GitHubService`` is instantiated in a process. Library consumers
+        can silence it with the standard ``warnings`` filter API, but
+        the warning is intentionally visible so new code is nudged
+        toward the provider abstraction.
+
         Args:
             timeout: Timeout in seconds for gh CLI commands (default: 30)
         """
+        _emit_deprecation_once()
         self.timeout = timeout
         self._provider: GitHubProvider | None = None
         self._verify_gh_cli()


### PR DESCRIPTION
## Summary

The original modernization plan framed this as \"migrate all callers off the shim and delete it\" — two PRs, 6 and 7. That framing turned out to be wrong: the provider abstraction at \`services/providers/github\` lacks **10+ operations** the shim exposes (\`list_bugs\`, \`close_issue\`, \`add_comment\`, \`fetch_epics\`, \`fetch_features_for_epic\`, \`create_epic\`, \`get_all_milestones\`, \`close_milestone\`, \`check_branch_exists\`, \`create_branch\`). A real migration has to extend \`GitHubProvider\` first, which is a multi-week scope of its own.

This PR does the **right amount** of work for this session — rather than a risky partial migration that leaves the tree in a worse state.

## Changes

- **Module docstring** rewritten from \"maintained for backward compatibility\" (vague) to an explicit list of: the methods the provider abstraction doesn't yet cover, the four callers still depending on the shim (\`fixit_service\`, \`github_linker\`, \`milestone_service\`, \`roadmapit_impl\`), and concrete per-caller migration options.
- **Class-level deprecation**: \`GitHubService\` gains a \`.. deprecated::\` directive in its docstring; \`__init__\` emits a one-time \`DeprecationWarning\`. Guarded by a module-level flag so only the **first** construction per process warns — tests stay quiet, developers touching the code see the signal.

## What this PR deliberately does **not** do

- **Delete the shim** (originally planned as PR 7). Blocked on GitHubProvider extensions. Tracked for a future initiative.
- **Migrate any caller off the shim**. Each caller uses methods the provider doesn't have yet. A partial migration where some callers use the provider and others use the shim is worse than status quo.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,735** tests pass
- [x] Deprecation warning shows up once per pytest run (documented signal, not a failure)
- [ ] CI green on Ubuntu / macOS / Windows

## Follow-up work (out of scope)

To eventually delete the shim, a future initiative needs to:

1. Add the missing methods to \`GitHubProvider\` (with matching models — \`Issue\` vs \`GitHubIssue\`, \`Milestone\` type differences resolved).
2. Migrate \`fixit_service\`, \`github_linker\`, \`milestone_service\`, \`roadmapit_impl\` to the provider one at a time.
3. Once zero callers remain, delete \`github_service.py\`.

Each step is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)