### PR TITLE
feat(github): extend GitHubProvider with branch ops + issue close/comment

### DIFF
--- a/src/doit_cli/services/providers/github.py
+++ b/src/doit_cli/services/providers/github.py
@@ -515,6 +515,126 @@ class GitHubProvider(GitProvider):
             raise ProviderError(f"Failed to parse GitHub response: {e}") from e
 
     # -------------------------------------------------------------------------
+    # Issue Comments and Closing
+    # -------------------------------------------------------------------------
+
+    def add_issue_comment(self, issue_id: str, comment: str) -> bool:
+        """Post a comment on an issue.
+
+        Args:
+            issue_id: Issue number (provider ID or the full "GH-123" form).
+            comment: Comment body text.
+
+        Returns:
+            True if the comment posted, False if the CLI returned a non-zero
+            exit code. Raises on auth/network failure.
+        """
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "comment", provider_id, "--body", comment],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
+
+    def close_issue(self, issue_id: str, comment: str | None = None) -> bool:
+        """Close an issue, optionally posting a closing comment first.
+
+        Args:
+            issue_id: Issue number (provider ID or the full "GH-123" form).
+            comment: Optional comment body to post before closing.
+
+        Returns:
+            True if the close succeeded. Raises on auth/network failure.
+        """
+        self._ensure_authenticated()
+        provider_id = self._extract_provider_id(issue_id)
+
+        cmd = ["gh", "issue", "close", provider_id]
+        if comment:
+            cmd.extend(["--comment", comment])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            raise NetworkError("GitHub CLI timeout", is_timeout=True) from None
+
+    # -------------------------------------------------------------------------
+    # Branch Operations
+    # -------------------------------------------------------------------------
+
+    def check_branch_exists(self, branch_name: str) -> tuple[bool, bool]:
+        """Check whether a branch exists locally and/or on the remote.
+
+        Runs `git branch --list` and `git ls-remote --heads origin <branch>`
+        to distinguish the two cases. Neither call requires network for the
+        local check; the remote check fails gracefully to `False` if the
+        remote is unreachable.
+
+        Returns:
+            Tuple of (local_exists, remote_exists).
+        """
+        local_exists = False
+        remote_exists = False
+
+        try:
+            local = subprocess.run(
+                ["git", "branch", "--list", branch_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            local_exists = bool(local.returncode == 0 and local.stdout.strip())
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+
+        try:
+            remote = subprocess.run(
+                ["git", "ls-remote", "--heads", "origin", branch_name],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            remote_exists = bool(remote.returncode == 0 and remote.stdout.strip())
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+
+        return local_exists, remote_exists
+
+    def create_branch(self, branch_name: str, from_branch: str = "main") -> bool:
+        """Create a new local branch from `from_branch` and switch to it.
+
+        Does not push to the remote. Callers that need a remote branch
+        should follow up with `git push -u origin <branch>` or use the
+        provider's PR APIs once work is staged.
+
+        Returns:
+            True if the branch was created, False if git returned non-zero.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "checkout", "-b", branch_name, from_branch],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False
+
+    # -------------------------------------------------------------------------
     # Helper Methods
     # -------------------------------------------------------------------------
 

--- a/tests/unit/test_github_provider_extensions.py
+++ b/tests/unit/test_github_provider_extensions.py
@@ -1,0 +1,154 @@
+"""Tests for the GitHubProvider methods added in the extension PR.
+
+Covers close_issue, add_issue_comment, check_branch_exists, create_branch —
+the four operations the legacy github_service shim exposed that the
+provider did not. We mock `subprocess.run` to exercise the command
+assembly and return-code branches without hitting gh CLI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from doit_cli.services.providers.github import GitHubProvider
+
+
+@pytest.fixture
+def provider() -> GitHubProvider:
+    return GitHubProvider(timeout=5)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> MagicMock:
+    """Build a CompletedProcess stub that returncode=0."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _fail(returncode: int = 1, stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = ""
+    m.stderr = stderr
+    return m
+
+
+class TestAddIssueComment:
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_posts_comment_returns_true_on_success(
+        self, mock_run, provider: GitHubProvider
+    ) -> None:
+        mock_run.side_effect = [_ok("ok"), _ok("ok")]  # auth + comment
+
+        result = provider.add_issue_comment("123", "looks good")
+
+        assert result is True
+        # The second call is the comment itself.
+        call_args = mock_run.call_args_list[1].args[0]
+        assert call_args[:4] == ["gh", "issue", "comment", "123"]
+        assert "--body" in call_args and "looks good" in call_args
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_returns_false_when_gh_fails(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok(), _fail(1, "rate limited")]
+        assert provider.add_issue_comment("123", "hi") is False
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_strips_unified_id_prefix(self, mock_run, provider: GitHubProvider) -> None:
+        """Unified IDs like `github:123` get reduced to the raw number."""
+        mock_run.side_effect = [_ok(), _ok()]
+        provider.add_issue_comment("github:123", "x")
+        call_args = mock_run.call_args_list[1].args[0]
+        assert call_args[3] == "123"
+
+
+class TestCloseIssue:
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_close_without_comment(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok(), _ok()]  # auth + close
+
+        assert provider.close_issue("42") is True
+        call_args = mock_run.call_args_list[1].args[0]
+        assert call_args == ["gh", "issue", "close", "42"]
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_close_with_comment(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok(), _ok()]
+
+        assert provider.close_issue("42", comment="done") is True
+        call_args = mock_run.call_args_list[1].args[0]
+        assert "--comment" in call_args
+        assert "done" in call_args
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_returns_false_on_gh_failure(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok(), _fail()]
+        assert provider.close_issue("42") is False
+
+
+class TestCheckBranchExists:
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_both_local_and_remote_found(
+        self, mock_run, provider: GitHubProvider
+    ) -> None:
+        mock_run.side_effect = [_ok("  feature-x"), _ok("abcdef123\trefs/heads/feature-x")]
+
+        local, remote = provider.check_branch_exists("feature-x")
+
+        assert local is True
+        assert remote is True
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_only_local(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok("  feature-x"), _ok("")]
+        local, remote = provider.check_branch_exists("feature-x")
+        assert local is True
+        assert remote is False
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_neither(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.side_effect = [_ok(""), _ok("")]
+        local, remote = provider.check_branch_exists("feature-missing")
+        assert local is False
+        assert remote is False
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_remote_unreachable_falls_back_to_false(
+        self, mock_run, provider: GitHubProvider
+    ) -> None:
+        mock_run.side_effect = [_ok("  feature-x"), subprocess.SubprocessError("offline")]
+        local, remote = provider.check_branch_exists("feature-x")
+        assert local is True
+        assert remote is False
+
+
+class TestCreateBranch:
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_checkout_new_branch(self, mock_run, provider: GitHubProvider) -> None:
+        mock_run.return_value = _ok()
+
+        assert provider.create_branch("feature-y", from_branch="main") is True
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args.args[0]
+        assert call_args == ["git", "checkout", "-b", "feature-y", "main"]
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_returns_false_on_git_failure(
+        self, mock_run, provider: GitHubProvider
+    ) -> None:
+        mock_run.return_value = _fail(128, "fatal: A branch named 'x' already exists")
+        assert provider.create_branch("x") is False
+
+    @patch("doit_cli.services.providers.github.subprocess.run")
+    def test_default_parent_branch_is_main(
+        self, mock_run, provider: GitHubProvider
+    ) -> None:
+        mock_run.return_value = _ok()
+        provider.create_branch("feature-z")
+        call_args = mock_run.call_args.args[0]
+        assert call_args[-1] == "main"


### PR DESCRIPTION
## Summary

The legacy \`services/github_service.py\` shim exposes 10+ operations not present on the \`services/providers/github.GitHubProvider\` abstraction. PR #801 deprecated the shim with a clear migration path; **this PR closes four of those gaps** by adding the operations to \`GitHubProvider\` itself.

## New methods

| Method | Purpose |
|:-------|:--------|
| \`close_issue(issue_id, comment=None)\` | Closes an issue, optionally posting a closing comment first |
| \`add_issue_comment(issue_id, comment)\` | Posts a comment on an issue |
| \`check_branch_exists(branch_name)\` | Returns \`(local_exists, remote_exists)\`. Remote failures fall back to \`False\` |
| \`create_branch(branch_name, from_branch="main")\` | Creates a new local branch via \`git checkout -b\`; does not push |

Both issue ops route through the existing \`_extract_provider_id()\` so unified IDs (\`github:123\`) and raw IDs (\`123\`) both work. Return \`bool\` for success/failure; raise on auth/network failures.

## Tests

\`tests/unit/test_github_provider_extensions.py\` — **13 new tests** mocking \`subprocess.run\` to verify:
- command assembly (exact arg lists)
- return-code branches (success + failure)
- unified ID prefix stripping
- remote-unreachable fallback for \`check_branch_exists\`

## What this unlocks

\`fixit_service\`, \`github_linker\`, and \`roadmapit_impl\` can now call \`GitHubProvider\` for these operations instead of the shim. Follow-up PR 11 migrates those callers.

## What it doesn't unlock yet

The remaining shim operations still need porting before \`github_service.py\` can be deleted:
- \`fetch_epics\` (filtered issue list)
- \`fetch_features_for_epic\` (body-reference parsing)
- \`create_epic\` (specialized \`create_issue\`)
- \`get_all_milestones\` (needs \"all\" state, current provider has open/closed)
- \`close_milestone\`

Each is its own PR.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] **1,748** tests pass (1,735 prior + 13 new)
- [ ] CI green on Ubuntu / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)