### PR TITLE
refactor(cli): migrate --format options onto format_option() helper

### DIFF
--- a/src/doit_cli/cli/analytics_command.py
+++ b/src/doit_cli/cli/analytics_command.py
@@ -22,9 +22,13 @@ from ..exit_codes import ExitCode
 from ..models.status_models import SpecState
 from ..services.analytics_service import AnalyticsService
 from ..services.spec_scanner import NotADoitProjectError, SpecNotFoundError
+from .output import OutputFormat, format_option, resolve_format
 
 app = typer.Typer(help="Spec analytics and metrics dashboard")
 console = Console()
+
+_TABULAR_FORMATS = (OutputFormat.TABLE, OutputFormat.JSON, OutputFormat.CSV)
+_EXPORT_FORMATS = (OutputFormat.MARKDOWN, OutputFormat.JSON)
 
 
 def _get_status_emoji(status: SpecState) -> str:
@@ -264,25 +268,28 @@ def _print_cycles_tables(stats, records, days: int | None, since: str | None) ->
 @app.command()
 def velocity(
     weeks: int = typer.Option(8, "--weeks", "-w", help="Number of weeks to display"),
-    format_type: str = typer.Option(
-        "table", "--format", "-f", help="Output format: table, json, csv"
+    format_type: str = format_option(
+        default=OutputFormat.TABLE,
+        allowed=_TABULAR_FORMATS,
     ),
 ) -> None:
     """Display velocity trends over time.
 
     Shows specs completed per week with visual indicators.
 
-    Exit codes:
-      0 - Success
-      1 - Insufficient data (< 2 weeks)
-      2 - Not a doit project
+    Exit codes (see doit_cli.exit_codes.ExitCode):
+      0 (SUCCESS)          — success
+      1 (FAILURE)          — insufficient data (< 2 weeks)
+      2 (VALIDATION_ERROR) — not a doit project
     """
+    fmt = resolve_format(format_type, _TABULAR_FORMATS)
+
     try:
         service = AnalyticsService()
         velocity_data = service.get_velocity_data(weeks=weeks)
 
         if len(velocity_data) < 2:
-            if format_type == "json":
+            if fmt is OutputFormat.JSON:
                 print(json.dumps({"success": False, "error": "Insufficient data"}))
             else:
                 console.print(
@@ -293,9 +300,9 @@ def velocity(
                     console.print(f"Available data points: {len(velocity_data)}")
             raise typer.Exit(code=ExitCode.FAILURE)
 
-        if format_type == "json":
+        if fmt is OutputFormat.JSON:
             _print_velocity_json(velocity_data)
-        elif format_type == "csv":
+        elif fmt is OutputFormat.CSV:
             _print_velocity_csv(velocity_data)
         else:
             _print_velocity_table(velocity_data, weeks)
@@ -507,8 +514,9 @@ def _print_spec_details(metadata) -> None:
 
 @app.command()
 def export(
-    format_type: str = typer.Option(
-        "markdown", "--format", "-f", help="Export format: markdown, json"
+    format_type: str = format_option(
+        default=OutputFormat.MARKDOWN,
+        allowed=_EXPORT_FORMATS,
     ),
     output_path: Path | None = typer.Option(None, "--output", "-o", help="Output file path"),
 ) -> None:
@@ -516,11 +524,13 @@ def export(
 
     Creates a report in .doit/reports/ by default.
 
-    Exit codes:
-      0 - Success
-      1 - Export failed
-      2 - Not a doit project
+    Exit codes (see doit_cli.exit_codes.ExitCode):
+      0 (SUCCESS)          — success
+      1 (FAILURE)          — export failed
+      2 (VALIDATION_ERROR) — not a doit project
     """
+    fmt = resolve_format(format_type, _EXPORT_FORMATS)
+
     try:
         service = AnalyticsService()
         report = service.generate_report()
@@ -531,11 +541,11 @@ def export(
             reports_dir.mkdir(parents=True, exist_ok=True)
 
             timestamp = datetime.now().strftime("%Y-%m-%d")
-            ext = "json" if format_type == "json" else "md"
+            ext = "json" if fmt is OutputFormat.JSON else "md"
             output_path = reports_dir / f"analytics-{timestamp}.{ext}"
 
         # Generate content
-        if format_type == "json":
+        if fmt is OutputFormat.JSON:
             content = json.dumps(report.to_dict(), indent=2)
         else:
             content = _generate_markdown_report(report)

--- a/src/doit_cli/cli/fixit_command.py
+++ b/src/doit_cli/cli/fixit_command.py
@@ -20,6 +20,9 @@ from ..prompts.fixit_prompts import (
 )
 from ..services.fixit_service import FixitService, FixitServiceError
 from ..services.github_service import GitHubServiceError
+from .output import OutputFormat, format_option, resolve_format
+
+_LIST_FORMATS = (OutputFormat.TABLE, OutputFormat.JSON)
 
 app = typer.Typer(help="Bug-fix workflow commands")
 console = Console()
@@ -112,7 +115,10 @@ def start(
 def list_bugs(
     label: str = typer.Option("bug", "--label", "-l", help="Label to filter by"),
     limit: int = typer.Option(20, "--limit", "-n", help="Maximum number of bugs to show"),
-    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table, json"),
+    output_format: str = format_option(
+        default=OutputFormat.TABLE,
+        allowed=_LIST_FORMATS,
+    ),
 ) -> None:
     """List open bugs from GitHub.
 
@@ -123,6 +129,8 @@ def list_bugs(
         doit fixit list --label high # List high priority issues
         doit fixit list --limit 10   # Show only 10 bugs
     """
+    fmt = resolve_format(output_format, _LIST_FORMATS)
+
     try:
         service = FixitService()
     except GitHubServiceError as e:
@@ -135,7 +143,7 @@ def list_bugs(
         console.print(f"[yellow]No open issues with label '{label}' found.[/yellow]")
         raise typer.Exit(code=ExitCode.SUCCESS)
 
-    if output_format == "json":
+    if fmt is OutputFormat.JSON:
         import json
 
         data = [bug.to_dict() for bug in bugs]

--- a/src/doit_cli/cli/xref_command.py
+++ b/src/doit_cli/cli/xref_command.py
@@ -13,6 +13,13 @@ from ..exit_codes import ExitCode
 from ..models.crossref_models import CoverageReport, CoverageStatus
 from ..services.crossref_service import CrossReferenceService
 from ..services.spec_scanner import NotADoitProjectError
+from .output import OutputFormat, format_option, resolve_format
+
+# Standard (rich, json, markdown) format set used by most xref reports.
+_REPORT_FORMATS = (OutputFormat.RICH, OutputFormat.JSON, OutputFormat.MARKDOWN)
+
+# Terse (rich, json) set for commands that don't carry a markdown variant.
+_TERSE_FORMATS = (OutputFormat.RICH, OutputFormat.JSON)
 
 console = Console()
 
@@ -157,8 +164,9 @@ def coverage_command(
     spec_name: str | None = typer.Argument(
         None, help="Spec directory name (default: auto-detect from branch)"
     ),
-    output_format: str = typer.Option(
-        "rich", "--format", "-f", help="Output format: rich, json, markdown"
+    output_format: str = format_option(
+        default=OutputFormat.RICH,
+        allowed=_REPORT_FORMATS,
     ),
     strict: bool = typer.Option(
         False, "--strict", "-s", help="Treat uncovered requirements as errors"
@@ -170,11 +178,13 @@ def coverage_command(
     Shows which requirements have implementing tasks and identifies
     any uncovered requirements or orphaned task references.
 
-    Exit codes:
-      0 - All requirements covered
-      1 - Uncovered requirements (with --strict) or errors
-      2 - Spec not found or invalid
+    Exit codes (see doit_cli.exit_codes.ExitCode):
+      0 (SUCCESS)          — all requirements covered
+      1 (FAILURE)          — uncovered requirements (with --strict) or orphans
+      2 (VALIDATION_ERROR) — spec not found or invalid
     """
+    fmt = resolve_format(output_format, _REPORT_FORMATS)
+
     try:
         # Auto-detect spec from branch if not provided
         if not spec_name:
@@ -186,15 +196,6 @@ def coverage_command(
                 )
                 raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
-        # Validate format
-        valid_formats = ["rich", "json", "markdown"]
-        if output_format not in valid_formats:
-            console.print(
-                f"[red]Error:[/red] Invalid format '{output_format}'. "
-                f"Valid: {', '.join(valid_formats)}"
-            )
-            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
-
         # Get coverage report
         service = CrossReferenceService()
         try:
@@ -204,21 +205,21 @@ def coverage_command(
             raise typer.Exit(code=ExitCode.VALIDATION_ERROR) from e
 
         # Format output
-        if output_format == "json":
-            output_str = _format_coverage_json(report)
-        elif output_format == "markdown":
+        if fmt is OutputFormat.JSON:
+            output_str: str | None = _format_coverage_json(report)
+        elif fmt is OutputFormat.MARKDOWN:
             output_str = _format_coverage_markdown(report)
         else:
             output_str = None  # Rich output handled separately
 
         # Write to file or stdout
         if output_file:
-            if output_format == "rich":
+            if fmt is OutputFormat.RICH:
                 # For rich format to file, use markdown instead
                 output_str = _format_coverage_markdown(report)
-            output_file.write_text(output_str)
+            output_file.write_text(output_str or "")
             console.print(f"[green]Report written to {output_file}[/green]")
-        elif output_format == "rich":
+        elif fmt is OutputFormat.RICH:
             _format_coverage_rich(report, console)
         else:
             print(output_str)
@@ -315,17 +316,20 @@ def locate_command(
 def tasks_command(
     requirement_id: str = typer.Argument(..., help="Requirement ID (e.g., FR-001)"),
     spec: str | None = typer.Option(None, "--spec", "-s", help="Spec name (default: auto-detect)"),
-    output_format: str = typer.Option(
-        "rich", "--format", "-f", help="Output format: rich, json, markdown"
+    output_format: str = format_option(
+        default=OutputFormat.RICH,
+        allowed=_REPORT_FORMATS,
     ),
 ) -> None:
     """List all tasks that implement a specific requirement.
 
-    Exit codes:
-      0 - Tasks found
-      1 - No tasks found for requirement
-      2 - Requirement or spec not found
+    Exit codes (see doit_cli.exit_codes.ExitCode):
+      0 (SUCCESS)          — tasks found
+      1 (FAILURE)          — no tasks found for requirement
+      2 (VALIDATION_ERROR) — requirement or spec not found
     """
+    fmt = resolve_format(output_format, _REPORT_FORMATS)
+
     try:
         # Determine spec name
         spec_name = spec or _detect_spec_from_branch()
@@ -333,15 +337,6 @@ def tasks_command(
             console.print(
                 "[red]Error:[/red] Could not detect spec. "
                 "Please provide --spec or run from a feature branch."
-            )
-            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
-
-        # Validate format
-        valid_formats = ["rich", "json", "markdown"]
-        if output_format not in valid_formats:
-            console.print(
-                f"[red]Error:[/red] Invalid format '{output_format}'. "
-                f"Valid: {', '.join(valid_formats)}"
             )
             raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
@@ -358,7 +353,7 @@ def tasks_command(
             raise typer.Exit(code=ExitCode.FAILURE)
 
         # Format output
-        if output_format == "json":
+        if fmt is OutputFormat.JSON:
             data = {
                 "requirement_id": requirement_id,
                 "tasks": [
@@ -373,7 +368,7 @@ def tasks_command(
                 "completed_count": sum(1 for t in tasks if t.completed),
             }
             print(json.dumps(data, indent=2))
-        elif output_format == "markdown":
+        elif fmt is OutputFormat.MARKDOWN:
             lines = [
                 f"# Tasks implementing {requirement_id}",
                 "",
@@ -425,7 +420,10 @@ def validate_command(
         None, help="Spec directory name (default: auto-detect from branch)"
     ),
     strict: bool = typer.Option(False, "--strict", "-s", help="Treat warnings as errors"),
-    output_format: str = typer.Option("rich", "--format", "-f", help="Output format: rich, json"),
+    output_format: str = format_option(
+        default=OutputFormat.RICH,
+        allowed=_TERSE_FORMATS,
+    ),
 ) -> None:
     """Validate cross-reference integrity between spec and tasks.
 
@@ -433,11 +431,13 @@ def validate_command(
     - Orphaned task references (tasks referencing non-existent requirements)
     - Uncovered requirements (requirements with no linked tasks)
 
-    Exit codes:
-      0 - All cross-references valid
-      1 - Validation errors found
-      2 - Files not found
+    Exit codes (see doit_cli.exit_codes.ExitCode):
+      0 (SUCCESS)          — all cross-references valid
+      1 (FAILURE)          — validation errors found
+      2 (VALIDATION_ERROR) — files not found
     """
+    fmt = resolve_format(output_format, _TERSE_FORMATS)
+
     try:
         # Auto-detect spec from branch if not provided
         if not spec_name:
@@ -448,15 +448,6 @@ def validate_command(
                     "Please provide spec name or run from a feature branch."
                 )
                 raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
-
-        # Validate format
-        valid_formats = ["rich", "json"]
-        if output_format not in valid_formats:
-            console.print(
-                f"[red]Error:[/red] Invalid format '{output_format}'. "
-                f"Valid: {', '.join(valid_formats)}"
-            )
-            raise typer.Exit(code=ExitCode.VALIDATION_ERROR)
 
         # Validate references
         service = CrossReferenceService()
@@ -476,7 +467,7 @@ def validate_command(
             warning_count = 0
 
         # Format output
-        if output_format == "json":
+        if fmt is OutputFormat.JSON:
             data = {
                 "spec": spec_name,
                 "valid": error_count == 0 and warning_count == 0,


### PR DESCRIPTION
Recreated from closed #803 after its base branch was deleted during the Phase 4 squash-merge, then rebased against the current develop. Migrates 6 `--format` call sites in fixit/xref/analytics onto the shared `format_option()` helper. See commit cb829c4 for full details.